### PR TITLE
Rescue CORS fix for stats-page workers

### DIFF
--- a/cloudflare/reactions-worker.js
+++ b/cloudflare/reactions-worker.js
@@ -14,7 +14,7 @@ export default {
     const cors = {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
     };
 
     if (request.method === "OPTIONS") {

--- a/cloudflare/view-counter-worker.js
+++ b/cloudflare/view-counter-worker.js
@@ -13,6 +13,7 @@ export default {
     const cors = {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Access-Control-Allow-Headers": "Authorization",
     };
 
     if (request.method === "OPTIONS") {


### PR DESCRIPTION
Cherry-picks the stranded commit from feature/stats_page: the stats page sends
Authorization: Bearer headers to both Cloudflare workers, but their CORS config
doesn't list Authorization in Access-Control-Allow-Headers, so the browser
preflight fails. This landed on the branch after the stats page merged but never
made it to main.

Note: the workers still need redeploying to Cloudflare after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh