### PR TITLE
Music hub: Discogs vinyl shelf + Spotify now-playing

### DIFF
--- a/.github/workflows/fetch-discogs.yaml
+++ b/.github/workflows/fetch-discogs.yaml
@@ -1,0 +1,34 @@
+name: Update Discogs Collection
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"  # every Monday at noon UTC
+  workflow_dispatch:      # allow manual trigger
+
+jobs:
+  update-discogs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Fetch Discogs collection
+        env:
+          DISCOGS_USERNAME: "tbdtbd"
+        run: python .github/scripts/fetch_discogs_collection.py
+
+      - name: Commit and push updates
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add data/discogs.json
+          git diff --quiet && git diff --staged --quiet || git commit -m "Update Discogs collection"
+          git push

--- a/.github/workflows/fetch-discogs.yaml
+++ b/.github/workflows/fetch-discogs.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-discogs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -23,12 +25,13 @@ jobs:
       - name: Fetch Discogs collection
         env:
           DISCOGS_USERNAME: "tbdtbd"
-        run: python .github/scripts/fetch_discogs_collection.py
+          DISCOGS_TOKEN: ${{ secrets.DISCOGS_TOKEN }}
+        run: python scripts/fetch_discogs_collection.py
 
       - name: Commit and push updates
         run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add data/discogs.json
-          git diff --quiet && git diff --staged --quiet || git commit -m "Update Discogs collection"
-          git push
+          git diff --staged --quiet || git commit -m "Update Discogs collection"
+          git pull && git push

--- a/cloudflare/SPOTIFY_SETUP.md
+++ b/cloudflare/SPOTIFY_SETUP.md
@@ -1,0 +1,40 @@
+# Spotify now-playing — one-time setup
+
+The music page shows a live "now playing" line fed by the `tbd-spotify` worker.
+Until these steps are done, the line simply stays hidden — nothing breaks.
+
+1. **Create a Spotify app**: go to
+   [developer.spotify.com/dashboard](https://developer.spotify.com/dashboard),
+   create an app (any name), and in its settings add this Redirect URI:
+
+   ```
+   http://127.0.0.1:8888/callback
+   ```
+
+   Note the **Client ID** and **Client Secret**.
+
+2. **Get a refresh token** (one time, on your machine):
+
+   ```bash
+   python scripts/spotify_get_refresh_token.py --client-id <ID> --client-secret <SECRET>
+   ```
+
+   A browser tab opens for consent; the token prints to the terminal.
+
+3. **Deploy the worker with secrets** (from the repo root):
+
+   ```bash
+   cd cloudflare
+   wrangler secret put SPOTIFY_CLIENT_ID -c spotify-wrangler.toml
+   wrangler secret put SPOTIFY_CLIENT_SECRET -c spotify-wrangler.toml
+   wrangler secret put SPOTIFY_REFRESH_TOKEN -c spotify-wrangler.toml
+   wrangler deploy -c spotify-wrangler.toml
+   ```
+
+4. **Check it**: `curl https://tbd-spotify.tomerno6.workers.dev/now` — you should
+   see `{"playing":...}` JSON. Play something on Spotify and reload the music
+   page; the `▶ now playing:` line appears in the header within ~45 s.
+
+Scopes used: `user-read-currently-playing`, `user-read-recently-played` (read-only).
+The worker caches responses for 30 s at the edge, so page traffic never hits
+Spotify rate limits.

--- a/cloudflare/spotify-worker.js
+++ b/cloudflare/spotify-worker.js
@@ -1,0 +1,96 @@
+// Cloudflare Worker — Spotify now-playing for tbd.codes
+//
+// API:
+//   GET /now → { playing: bool, track, artist, art, url } | { playing: false }
+//
+// Secrets (wrangler secret put ...): SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET,
+// SPOTIFY_REFRESH_TOKEN. See cloudflare/SPOTIFY_SETUP.md for the one-time setup.
+// Responses are cached ~30s at the edge to stay far from Spotify rate limits.
+
+const ALLOWED_ORIGINS = ["https://tbd.codes", "http://localhost:8080", "http://127.0.0.1:8080"];
+
+export default {
+  async fetch(request, env, ctx) {
+    const origin = request.headers.get("Origin") || "";
+    const cors = {
+      "Access-Control-Allow-Origin": ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0],
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Vary": "Origin",
+    };
+    if (request.method === "OPTIONS") return new Response(null, { status: 204, headers: cors });
+
+    const url = new URL(request.url);
+    if (url.pathname !== "/now") return json({ error: "not found" }, 404, cors);
+
+    const cacheKey = new Request("https://tbd-spotify.cache/now");
+    const cache = caches.default;
+    const cached = await cache.match(cacheKey);
+    if (cached) {
+      const body = await cached.text();
+      return new Response(body, { headers: { ...cors, "Content-Type": "application/json" } });
+    }
+
+    try {
+      const token = await accessToken(env);
+      let payload = await nowPlaying(token);
+      if (!payload) payload = await lastPlayed(token);
+      if (!payload) payload = { playing: false };
+      const res = json(payload, 200, { ...cors, "Cache-Control": "s-maxage=30" });
+      ctx.waitUntil(cache.put(cacheKey, res.clone()));
+      return res;
+    } catch (e) {
+      // Widget-friendly: errors surface as "nothing playing", never break the page
+      return json({ playing: false, error: String(e).slice(0, 100) }, 200, cors);
+    }
+  },
+};
+
+async function accessToken(env) {
+  const r = await fetch("https://accounts.spotify.com/api/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: "Basic " + btoa(`${env.SPOTIFY_CLIENT_ID}:${env.SPOTIFY_CLIENT_SECRET}`),
+    },
+    body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: env.SPOTIFY_REFRESH_TOKEN }),
+  });
+  if (!r.ok) throw new Error(`token ${r.status}`);
+  return (await r.json()).access_token;
+}
+
+function trackPayload(item, playing) {
+  return {
+    playing,
+    track: item.name,
+    artist: (item.artists || []).map((a) => a.name).join(", "),
+    art: item.album && item.album.images && item.album.images[1] ? item.album.images[1].url : null,
+    url: item.external_urls ? item.external_urls.spotify : null,
+  };
+}
+
+async function nowPlaying(token) {
+  const r = await fetch("https://api.spotify.com/v1/me/player/currently-playing", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (r.status !== 200) return null; // 204 = nothing playing
+  const data = await r.json();
+  if (!data || !data.item) return null;
+  return trackPayload(data.item, !!data.is_playing);
+}
+
+async function lastPlayed(token) {
+  const r = await fetch("https://api.spotify.com/v1/me/player/recently-played?limit=1", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!r.ok) return null;
+  const data = await r.json();
+  const item = data.items && data.items[0] && data.items[0].track;
+  return item ? trackPayload(item, false) : null;
+}
+
+function json(obj, status, headers) {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}

--- a/cloudflare/spotify-wrangler.toml
+++ b/cloudflare/spotify-wrangler.toml
@@ -1,0 +1,3 @@
+name = "tbd-spotify"
+main = "spotify-worker.js"
+compatibility_date = "2025-01-01"

--- a/css/style.css
+++ b/css/style.css
@@ -1348,3 +1348,46 @@ nav {
   font-size: 0.75em;
   color: var(--fg-dim);
 }
+
+/* Music - now playing line (hidden until the spotify worker responds) */
+.now-playing {
+  font-size: 0.85em;
+  color: var(--accent);
+  margin: -0.4em 0 1em;
+}
+
+.now-playing a {
+  color: var(--amber);
+  text-decoration: none;
+}
+
+.now-playing a:hover {
+  text-decoration: underline;
+}
+
+.eq {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 0.9em;
+  vertical-align: text-bottom;
+}
+
+.eq i {
+  width: 3px;
+  background: var(--accent);
+  animation: eq-bounce 1s ease-in-out infinite;
+}
+
+.eq i:nth-child(1) { height: 40%; animation-delay: 0s; }
+.eq i:nth-child(2) { height: 100%; animation-delay: 0.2s; }
+.eq i:nth-child(3) { height: 65%; animation-delay: 0.4s; }
+
+@keyframes eq-bounce {
+  0%, 100% { transform: scaleY(0.4); }
+  50% { transform: scaleY(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .eq i { animation: none; }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -1266,3 +1266,85 @@ nav {
     animation: none !important;
   }
 }
+
+/* Music - vinyl shelf */
+.vinyl-shelf {
+  margin-top: 2.5em;
+}
+
+.vinyl-genres {
+  display: flex;
+  gap: 0.4em;
+  flex-wrap: wrap;
+  margin: 0.6em 0 1em;
+}
+
+.vinyl-genre-chip {
+  background: none;
+  border: 1px solid var(--accent-40);
+  color: var(--accent);
+  font-family: "Fira Code", monospace;
+  font-size: 0.8em;
+  border-radius: 4px;
+  padding: 0.15em 0.6em;
+  cursor: pointer;
+}
+
+.vinyl-genre-chip:hover {
+  background: var(--accent-15);
+}
+
+.vinyl-genre-chip.active {
+  background: var(--accent);
+  color: var(--ph-0);
+  font-weight: bold;
+}
+
+.vinyl-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 1em;
+}
+
+.vinyl-card {
+  background: var(--ph-2);
+  border: 1px solid var(--accent-08);
+  border-radius: 6px;
+  padding: 0.6em;
+  transition: border-color 0.15s;
+}
+
+.vinyl-card:hover {
+  border-color: var(--accent-40);
+}
+
+.vinyl-cover {
+  aspect-ratio: 1;
+  background: var(--ph-0);
+  border-radius: 4px;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--amber);
+  font-size: 2em;
+  margin-bottom: 0.5em;
+}
+
+.vinyl-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.vinyl-title {
+  font-size: 0.85em;
+  color: var(--fg);
+  overflow-wrap: break-word;
+}
+
+.vinyl-meta {
+  font-size: 0.75em;
+  color: var(--fg-dim);
+}

--- a/js/music-nowplaying.js
+++ b/js/music-nowplaying.js
@@ -1,0 +1,35 @@
+// Music page: live "now playing" line fed by the tbd-spotify worker.
+// Invisible unless the worker responds with a track. See cloudflare/SPOTIFY_SETUP.md.
+(function () {
+  const el = document.getElementById("now-playing");
+  if (!el) return;
+  const WORKER = "https://tbd-spotify.tomerno6.workers.dev";
+
+  function render(d) {
+    if (!d || !d.track) { el.classList.add("hidden"); return; }
+    el.innerHTML = "";
+    if (d.playing) {
+      const eq = document.createElement("span");
+      eq.className = "eq";
+      eq.innerHTML = "<i></i><i></i><i></i>";
+      el.appendChild(eq);
+    }
+    el.appendChild(document.createTextNode(d.playing ? " now playing: " : " last played: "));
+    const a = document.createElement("a");
+    if (d.url) { a.href = d.url; a.target = "_blank"; a.rel = "noopener"; }
+    const bdi = document.createElement("bdi");
+    bdi.textContent = `${d.artist} — ${d.track}`;
+    a.appendChild(bdi);
+    el.appendChild(a);
+    el.classList.remove("hidden");
+  }
+
+  function poll() {
+    fetch(`${WORKER}/now`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then(render)
+      .catch(() => el.classList.add("hidden"));
+  }
+  poll();
+  setInterval(poll, 45000);
+})();

--- a/js/music-shelf.js
+++ b/js/music-shelf.js
@@ -1,0 +1,91 @@
+// Music page: the vinyl shelf — Discogs collection rendered as an album grid.
+// Hidden entirely when data/discogs.json is absent or empty.
+(function () {
+  const shelfEl = document.getElementById("vinyl-shelf");
+  if (!shelfEl) return;
+
+  fetch("data/discogs.json")
+    .then((r) => (r.ok ? r.json() : []))
+    .then((releases) => {
+      if (!Array.isArray(releases) || releases.length === 0) return;
+
+      shelfEl.classList.remove("hidden");
+      const header = document.createElement("p");
+      header.className = "song-log-header";
+      header.textContent = `$ ls ~/vinyl  # ${releases.length} records`;
+      shelfEl.appendChild(header);
+
+      // Genre chips (top genres by count, max 8)
+      const genreCounts = {};
+      releases.forEach((r) => (r.genres || []).forEach((g) => {
+        genreCounts[g] = (genreCounts[g] || 0) + 1;
+      }));
+      const genres = Object.keys(genreCounts).sort((a, b) => genreCounts[b] - genreCounts[a]).slice(0, 8);
+
+      let activeGenre = null;
+      const chipsEl = document.createElement("div");
+      chipsEl.className = "vinyl-genres";
+      const grid = document.createElement("div");
+      grid.className = "vinyl-grid";
+
+      function renderGrid() {
+        grid.innerHTML = "";
+        releases
+          .filter((r) => !activeGenre || (r.genres || []).includes(activeGenre))
+          .forEach((r) => {
+            const card = document.createElement("div");
+            card.className = "vinyl-card";
+            const cover = document.createElement("div");
+            cover.className = "vinyl-cover";
+            if (r.cover) {
+              const img = document.createElement("img");
+              img.src = r.cover;
+              img.alt = `${r.artist} — ${r.title}`;
+              img.loading = "lazy";
+              cover.appendChild(img);
+            } else {
+              cover.textContent = "♪";
+            }
+            const title = document.createElement("div");
+            title.className = "vinyl-title";
+            const tbdi = document.createElement("bdi");
+            tbdi.textContent = r.title || "";
+            title.appendChild(tbdi);
+            const meta = document.createElement("div");
+            meta.className = "vinyl-meta";
+            const mbdi = document.createElement("bdi");
+            mbdi.textContent = r.artist || "";
+            meta.appendChild(mbdi);
+            if (r.year) meta.appendChild(document.createTextNode(` · ${r.year}`));
+            card.appendChild(cover);
+            card.appendChild(title);
+            card.appendChild(meta);
+            grid.appendChild(card);
+          });
+      }
+
+      if (genres.length > 1) {
+        const mkChip = (label, genre) => {
+          const b = document.createElement("button");
+          b.type = "button";
+          b.className = "vinyl-genre-chip";
+          b.textContent = label;
+          b.addEventListener("click", () => {
+            activeGenre = genre;
+            chipsEl.querySelectorAll(".vinyl-genre-chip").forEach((c) => c.classList.toggle("active", c === b));
+            renderGrid();
+          });
+          return b;
+        };
+        const all = mkChip("all", null);
+        all.classList.add("active");
+        chipsEl.appendChild(all);
+        genres.forEach((g) => chipsEl.appendChild(mkChip(g.toLowerCase(), g)));
+        shelfEl.appendChild(chipsEl);
+      }
+
+      shelfEl.appendChild(grid);
+      renderGrid();
+    })
+    .catch(() => { /* no shelf */ });
+})();

--- a/music.html
+++ b/music.html
@@ -20,6 +20,7 @@
       </aside>
       <main class="main-content">
         <h1>Music</h1>
+        <p id="now-playing" class="now-playing hidden"></p>
         <p class="song-log-intro">
           every travel day ends with a song. this is the log — one track per day,
           in trip order. ♪ plays it, → opens the day.
@@ -35,5 +36,6 @@
     <script src="js/main.js"></script>
     <script src="js/music.js"></script>
     <script src="js/music-shelf.js"></script>
+    <script src="js/music-nowplaying.js"></script>
   </body>
 </html>

--- a/music.html
+++ b/music.html
@@ -27,11 +27,13 @@
         <div id="song-log" class="song-log">
           <p class="song-log-loading">loading songs…</p>
         </div>
+        <div id="vinyl-shelf" class="vinyl-shelf hidden"></div>
       </main>
     </div>
     <footer></footer>
     <script src="js/include-components.js"></script>
     <script src="js/main.js"></script>
     <script src="js/music.js"></script>
+    <script src="js/music-shelf.js"></script>
   </body>
 </html>

--- a/scripts/fetch_discogs_collection.py
+++ b/scripts/fetch_discogs_collection.py
@@ -1,0 +1,48 @@
+import requests, json, os
+
+USERNAME = os.environ.get("DISCOGS_USERNAME", "tbdtbd")
+OUTPUT_PATH = "data/discogs.json"
+
+BASE_URL = f"https://api.discogs.com/users/{USERNAME}/collection/folders/0/releases"
+
+def fetch_collection():
+    page = 1
+    per_page = 100
+    all_releases = []
+
+    while True:
+        print(f"Fetching page {page}...")
+        resp = requests.get(BASE_URL, headers={
+            "User-Agent": "MyDiscogsSite/1.0"
+        }, params={"page": page, "per_page": per_page})
+        data = resp.json()
+
+        releases = data.get("releases", [])
+        if not releases:
+            break
+
+        for r in releases:
+            info = r.get("basic_information", {})
+            all_releases.append({
+                "id": info.get("id"),
+                "title": info.get("title"),
+                "artist": ", ".join(a["name"] for a in info.get("artists", [])),
+                "year": info.get("year"),
+                "genres": info.get("genres", []),
+                "styles": info.get("styles", []),
+                "formats": [f["name"] for f in info.get("formats", [])],
+                "cover": info.get("cover_image"),
+            })
+
+        if data.get("pagination", {}).get("pages", 0) <= page:
+            break
+        page += 1
+
+    os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
+    with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
+        json.dump(all_releases, f, ensure_ascii=False, indent=2)
+
+    print(f"Saved {len(all_releases)} releases to {OUTPUT_PATH}")
+
+if __name__ == "__main__":
+    fetch_collection()

--- a/scripts/fetch_discogs_collection.py
+++ b/scripts/fetch_discogs_collection.py
@@ -1,20 +1,41 @@
-import requests, json, os
+"""Fetch the Discogs collection into data/discogs.json.
+
+Auth: the collection is private on Discogs, so either
+  - set DISCOGS_TOKEN (personal access token from discogs.com/settings/developers), or
+  - make the collection public in Discogs privacy settings (no token needed).
+
+Fails loudly on API errors and refuses to overwrite existing data with an
+empty result, so a misconfigured run can never blank the shelf.
+"""
+import json
+import os
+import sys
+
+import requests
 
 USERNAME = os.environ.get("DISCOGS_USERNAME", "tbdtbd")
+TOKEN = os.environ.get("DISCOGS_TOKEN", "")
 OUTPUT_PATH = "data/discogs.json"
 
 BASE_URL = f"https://api.discogs.com/users/{USERNAME}/collection/folders/0/releases"
 
+
 def fetch_collection():
+    headers = {"User-Agent": "tbd.codes vinyl shelf/1.0"}
+    if TOKEN:
+        headers["Authorization"] = f"Discogs token={TOKEN}"
+
     page = 1
     per_page = 100
     all_releases = []
 
     while True:
         print(f"Fetching page {page}...")
-        resp = requests.get(BASE_URL, headers={
-            "User-Agent": "MyDiscogsSite/1.0"
-        }, params={"page": page, "per_page": per_page})
+        resp = requests.get(BASE_URL, headers=headers, params={"page": page, "per_page": per_page})
+        if resp.status_code != 200:
+            msg = resp.json().get("message", resp.text[:200])
+            sys.exit(f"Discogs API error {resp.status_code}: {msg}\n"
+                     "Hint: set DISCOGS_TOKEN or make the collection public.")
         data = resp.json()
 
         releases = data.get("releases", [])
@@ -38,11 +59,20 @@ def fetch_collection():
             break
         page += 1
 
+    if not all_releases and os.path.exists(OUTPUT_PATH):
+        try:
+            existing = json.load(open(OUTPUT_PATH, encoding="utf-8"))
+        except Exception:
+            existing = []
+        if existing:
+            sys.exit("Refusing to overwrite non-empty data/discogs.json with an empty collection.")
+
     os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
     with open(OUTPUT_PATH, "w", encoding="utf-8") as f:
         json.dump(all_releases, f, ensure_ascii=False, indent=2)
 
     print(f"Saved {len(all_releases)} releases to {OUTPUT_PATH}")
+
 
 if __name__ == "__main__":
     fetch_collection()

--- a/scripts/spotify_get_refresh_token.py
+++ b/scripts/spotify_get_refresh_token.py
@@ -1,0 +1,96 @@
+"""One-time helper: obtain a Spotify refresh token for the now-playing worker.
+
+Usage:
+    python scripts/spotify_get_refresh_token.py --client-id XXX --client-secret YYY
+
+Prerequisite: a Spotify app (developer.spotify.com/dashboard) with redirect URI
+http://127.0.0.1:8888/callback added in its settings.
+
+Opens the browser for consent, catches the callback on a local HTTP server,
+exchanges the code, and prints the refresh token to paste into
+`wrangler secret put SPOTIFY_REFRESH_TOKEN`.
+"""
+import argparse
+import base64
+import json
+import sys
+import threading
+import urllib.parse
+import urllib.request
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+REDIRECT_URI = "http://127.0.0.1:8888/callback"
+SCOPES = "user-read-currently-playing user-read-recently-played"
+
+code_holder = {}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        query = urllib.parse.urlparse(self.path).query
+        params = urllib.parse.parse_qs(query)
+        if "code" in params:
+            code_holder["code"] = params["code"][0]
+            body = b"<h1>Done. You can close this tab.</h1>"
+        else:
+            body = b"<h1>No code in callback.</h1>"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Get a Spotify refresh token")
+    ap.add_argument("--client-id", required=True)
+    ap.add_argument("--client-secret", required=True)
+    args = ap.parse_args()
+
+    auth_url = "https://accounts.spotify.com/authorize?" + urllib.parse.urlencode({
+        "client_id": args.client_id,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPES,
+    })
+
+    server = HTTPServer(("127.0.0.1", 8888), Handler)
+    thread = threading.Thread(target=server.handle_request)
+    thread.start()
+
+    print("Opening browser for Spotify consent...")
+    print("If it does not open, visit:\n" + auth_url)
+    webbrowser.open(auth_url)
+    thread.join(timeout=300)
+    server.server_close()
+
+    code = code_holder.get("code")
+    if not code:
+        sys.exit("No authorization code received (timed out after 5 minutes).")
+
+    basic = base64.b64encode(f"{args.client_id}:{args.client_secret}".encode()).decode()
+    data = urllib.parse.urlencode({
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": REDIRECT_URI,
+    }).encode()
+    req = urllib.request.Request(
+        "https://accounts.spotify.com/api/token",
+        data=data,
+        headers={"Authorization": f"Basic {basic}", "Content-Type": "application/x-www-form-urlencoded"},
+    )
+    with urllib.request.urlopen(req) as resp:
+        tokens = json.load(resp)
+
+    refresh = tokens.get("refresh_token")
+    if not refresh:
+        sys.exit(f"No refresh token in response: {tokens}")
+    print("\nYour refresh token (feed it to `wrangler secret put SPOTIFY_REFRESH_TOKEN`):\n")
+    print(refresh)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Vinyl shelf (Discogs)

Rescues the parked `feature/discogs_collection` scaffold and finishes it:

- Fixed the workflow path bug (`.github/scripts/` → `scripts/`) + bot identity + `contents: write`
- **Found why the branch stalled: the collection is private on Discogs.** The script now authenticates via a `DISCOGS_TOKEN` secret (or works unauthenticated if you make the collection public), exits loudly on API errors, and refuses to overwrite non-empty data with an empty result
- New `js/music-shelf.js`: `$ ls ~/vinyl` album grid with covers, genre chip filter, bdi-safe titles — hidden until `data/discogs.json` has content

## Spotify now-playing

- New `cloudflare/spotify-worker.js` (`tbd-spotify`, same flat pattern as the other two workers): `GET /now` → currently-playing with last-played fallback, refresh-token grant, 30s edge cache, CORS locked to tbd.codes + local preview
- `js/music-nowplaying.js`: polls every 45s, renders `▶ now playing: artist — track` with a 3-bar equalizer (respects reduced motion), invisible whenever the worker is silent
- One-time setup kit: `scripts/spotify_get_refresh_token.py` (local OAuth dance) + `cloudflare/SPOTIFY_SETUP.md`

## Your setup steps (page is safe to ship before them)

1. **Discogs**: either make your collection public in Discogs privacy settings, or add a `DISCOGS_TOKEN` repo secret (token from discogs.com/settings/developers), then run the "Update Discogs Collection" workflow manually
2. **Spotify**: follow `cloudflare/SPOTIFY_SETUP.md` (create app → run helper → 3 secrets → deploy)

## Verification

- Shelf: mock-injected 4-record collection renders grid + working genre filter; 404 data → section hidden, zero console errors
- Now-playing: worker-down → hidden cleanly; mocked playing-track → renders with equalizer; screenshots attached to session
- Worker/helper pass `node --check` / `ast.parse`

Base is `feature/music-page` (stack top); retargets to `main` on stack merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh