### PR TITLE
Vinyl cards link to Discogs; song log scrolls in place

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -746,6 +746,16 @@ nav {
   font-size: 0.9em;
 }
 
+/* The log scrolls in place (same pattern as #posts-container) so the
+   vinyl shelf below isn't buried under 190+ rows */
+.song-log {
+  max-height: 60vh;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--accent-40) transparent;
+  padding-right: 0.4em;
+}
+
 .song-log-header {
   color: var(--fg-dim);
   font-size: 0.85em;
@@ -1307,11 +1317,14 @@ nav {
 }
 
 .vinyl-card {
+  display: block;
   background: var(--ph-2);
   border: 1px solid var(--accent-08);
   border-radius: 6px;
   padding: 0.6em;
   transition: border-color 0.15s;
+  text-decoration: none;
+  color: inherit;
 }
 
 .vinyl-card:hover {

--- a/js/music-shelf.js
+++ b/js/music-shelf.js
@@ -33,8 +33,15 @@
         releases
           .filter((r) => !activeGenre || (r.genres || []).includes(activeGenre))
           .forEach((r) => {
-            const card = document.createElement("div");
+            // Cards link to the release on Discogs (details, pressings, market)
+            const card = document.createElement(r.id ? "a" : "div");
             card.className = "vinyl-card";
+            if (r.id) {
+              card.href = "https://www.discogs.com/release/" + r.id;
+              card.target = "_blank";
+              card.rel = "noopener";
+              card.title = (r.artist || "") + " — " + (r.title || "") + " on Discogs";
+            }
             const cover = document.createElement("div");
             cover.className = "vinyl-cover";
             if (r.cover) {


### PR DESCRIPTION
- Every vinyl card is now an `<a>` to its canonical Discogs release page (`discogs.com/release/<id>`), new tab, noopener — hover tooltip carries artist — title
- The song log becomes a 60vh scroll-in-place container (same pattern as the blog's #posts-container) so the shelf starts ~900px from the top instead of ~7,000px

Verified: 119/119 cards linked (sample href checks out), log scrolls internally (600px window over 6,488px), shelf header + genre chips visible one scroll down, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh