### PR TITLE
Projects: gate README rendering behind a [y/N] prompt

### DIFF
--- a/js/projects-terminal.js
+++ b/js/projects-terminal.js
@@ -110,6 +110,54 @@
       .catch(function () { return null; });
   }
 
+  // A full README dumped mid-session breaks the shell flow, so cat offers
+  // it behind a [y/N] prompt. The next input answers; any other command
+  // silently cancels the offer and runs normally.
+  var pendingReadme = null;
+
+  function renderReadme(p) {
+    var loading = line("reading " + escapeHtml(p.repo) + "/README.md…", "term-dim");
+    fetchReadme(p.repo).then(function (md) {
+      loading.remove();
+      if (!md) {
+        line("could not read " + escapeHtml(p.repo) + "/README.md", "term-dim");
+        return;
+      }
+      var el = line("", "term-cat-body");
+      el.innerHTML = window.marked.parse(md);
+      // Relative README asset paths resolve against the raw repo root
+      var base = "https://raw.githubusercontent.com/" + GH_USER + "/" + p.repo + "/HEAD/";
+      el.querySelectorAll("img").forEach(function (img) {
+        var src = img.getAttribute("src") || "";
+        if (src && !/^([a-z]+:)?\/\//i.test(src) && !src.startsWith("data:")) img.src = base + src.replace(/^\.?\//, "");
+        img.loading = "lazy";
+      });
+      el.querySelectorAll("a").forEach(function (a) {
+        a.target = "_blank";
+        a.rel = "noopener";
+      });
+      line("&nbsp;");
+      root.scrollTop = root.scrollHeight;
+    });
+  }
+
+  function offerReadme(p) {
+    var prompt = line("", "term-dim");
+    prompt.appendChild(document.createTextNode("read " + p.repo + "/README.md? ["));
+    var yes = document.createElement("a");
+    yes.href = "#";
+    yes.className = "term-accent";
+    yes.textContent = "y";
+    yes.addEventListener("click", function (e) {
+      e.preventDefault();
+      term.run("y");
+      term.focus();
+    });
+    prompt.appendChild(yes);
+    prompt.appendChild(document.createTextNode("/N]"));
+    pendingReadme = p;
+  }
+
   function cat(slug) {
     var p = bySlug[slug];
     if (!p) {
@@ -124,28 +172,10 @@
     if (links.length) line(links.join("&nbsp;&nbsp;"));
 
     if (p.repo && window.marked) {
-      var loading = line("reading " + escapeHtml(p.repo) + "/README.md…", "term-dim");
-      fetchReadme(p.repo).then(function (md) {
-        loading.remove();
-        if (!md) return; // repo private/renamed/offline — blurb already printed
-        var el = line("", "term-cat-body");
-        el.innerHTML = window.marked.parse(md);
-        // Relative README asset paths resolve against the raw repo root
-        var base = "https://raw.githubusercontent.com/" + GH_USER + "/" + p.repo + "/HEAD/";
-        el.querySelectorAll("img").forEach(function (img) {
-          var src = img.getAttribute("src") || "";
-          if (src && !/^([a-z]+:)?\/\//i.test(src) && !src.startsWith("data:")) img.src = base + src.replace(/^\.?\//, "");
-          img.loading = "lazy";
-        });
-        el.querySelectorAll("a").forEach(function (a) {
-          a.target = "_blank";
-          a.rel = "noopener";
-        });
-        line("&nbsp;");
-        root.scrollTop = root.scrollHeight;
-      });
+      offerReadme(p);
+    } else {
+      line("&nbsp;");
     }
-    line("&nbsp;");
   }
 
   var COMMANDS = {
@@ -192,6 +222,15 @@
   };
 
   function exec(cmd) {
+    if (pendingReadme) {
+      var offered = pendingReadme;
+      pendingReadme = null;
+      var answer = cmd.trim().toLowerCase();
+      if (answer === "y" || answer === "yes") { renderReadme(offered); return; }
+      if (answer === "n" || answer === "no") { line("(skipped)", "term-dim"); return; }
+      // any other input: drop the offer and run it as a normal command
+    }
+
     var parts = cmd.split(/\s+/);
     var name = parts[0].toLowerCase();
     var args = parts.slice(1);

--- a/tests/smoke/projects.spec.js
+++ b/tests/smoke/projects.spec.js
@@ -32,8 +32,35 @@ test("cat renders the repo README, and survives its absence", async ({ page }) =
   await page.goto("/projects.html", { waitUntil: "domcontentloaded" });
   await page.waitForSelector(".proj-open", { timeout: 15000 });
   await page.locator(".proj-open").first().click();
+  // README is gated behind a [y/N] prompt
+  await expect(page.locator(".term-scrollback")).toContainText("README.md? [");
+  await expect(page.locator(".term-cat-body")).toHaveCount(0);
+  await page.fill("#term-input", "y");
+  await page.press("#term-input", "Enter");
   await expect(page.locator(".term-cat-body h1")).toContainText("Fixture Readme");
   await expect(page.locator(".term-cat-body")).toContainText("readme prose");
+  expect(errors).toEqual([]);
+});
+
+test("declining or ignoring the README offer keeps the session flowing", async ({ page }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://api.github.com/repos/**", (r) => r.fulfill({ json: { stargazers_count: 1 } }));
+  await page.route("https://raw.githubusercontent.com/**", (r) =>
+    r.fulfill({ body: "# Fixture Readme", contentType: "text/plain", headers: { "Access-Control-Allow-Origin": "*" } })
+  );
+  await page.goto("/projects.html", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector(".proj-open", { timeout: 15000 });
+  await page.locator(".proj-open").first().click();
+  await page.fill("#term-input", "n");
+  await page.press("#term-input", "Enter");
+  await expect(page.locator(".term-scrollback")).toContainText("(skipped)");
+  await expect(page.locator(".term-cat-body")).toHaveCount(0);
+  // A different command while the offer is pending cancels it and just runs
+  await page.locator(".proj-open").first().click();
+  await page.fill("#term-input", "help");
+  await page.press("#term-input", "Enter");
+  await expect(page.locator(".term-scrollback")).toContainText("available commands");
+  await expect(page.locator(".term-cat-body")).toHaveCount(0);
   expect(errors).toEqual([]);
 });
 
@@ -46,7 +73,9 @@ test("cat falls back to the blurb when the README is unreachable", async ({ page
   await page.waitForSelector(".proj-open", { timeout: 15000 });
   await page.locator(".proj-open").first().click();
   await expect(page.locator(".term-scrollback")).toContainText(index[0].blurb.slice(0, 25));
-  await page.waitForTimeout(800);
+  await page.fill("#term-input", "y");
+  await page.press("#term-input", "Enter");
+  await expect(page.locator(".term-scrollback")).toContainText("could not read");
   await expect(page.locator(".term-cat-body")).toHaveCount(0);
   expect(errors).toEqual([]);
 });


### PR DESCRIPTION
Feedback: the full README render broke up the terminal session. `cat` now offers it instead of dumping it:

- `cat <slug>` → name/blurb/links + `read <repo>/README.md? [y/N]` (the y is clickable for touch)
- `y`/`yes` renders; `n`/`no` prints `(skipped)`; any other input cancels the offer and runs as a normal command — so a pending prompt never eats your next command
- Unreachable README after `y` → a dim `could not read` line, nothing else

Suite: 15 passed (render-on-y, skip-on-n, cancel-on-other-command, unreachable-fallback all covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh