### PR TITLE
Finish phosphor token migration, delete deprecated CSS aliases

### DIFF
--- a/404.html
+++ b/404.html
@@ -29,7 +29,7 @@
         letter-spacing: -2px;
       }
       .error-msg {
-        color: var(--fg-bright, #d6f5e3);
+        color: var(--fg, #d6f5e3);
         font-size: 1rem;
         margin: 0.5em 0 1.5em;
       }

--- a/css/comment-widget-dark.css
+++ b/css/comment-widget-dark.css
@@ -73,7 +73,7 @@
     /* text-transform: uppercase; */
     color: var(--accent);
     background: none;
-    border: 1px solid var(--accent-faded);
+    border: 1px solid var(--accent-40);
     border-radius: 3px;
     transition: background 0.2s, color 0.2s;
     font-family: 'Fira Code', monospace;
@@ -201,7 +201,7 @@
     font-size: 14px;
     text-align: justify;
     color: var(--accent);
-    background-color: var(--bg-darker);
+    background-color: var(--ph-1);
     font-family: 'Fira Code', monospace;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -18,13 +18,6 @@
   /* Physics */
   --bloom: 0 0 8px rgba(57, 255, 20, 0.35);
   --bezel: inset 0 0 0 1px rgba(57, 255, 20, 0.08), inset 0 0 24px rgba(0, 0, 0, 0.4);
-
-  /* Deprecated aliases — semantics moved: page is now the darkest layer,
-     panels sit raised above it. Migrate usages, then delete. */
-  --bg-dark: var(--ph-0);
-  --bg-darker: var(--ph-1);
-  --fg-bright: var(--fg);
-  --accent-faded: var(--accent-40);
 }
 
 body {
@@ -122,7 +115,7 @@ nav {
   max-width: 900px;
   margin: 2em auto;
   gap: 2em;
-  /* background: var(--bg-dark); */
+  /* background: var(--ph-0); */
   border-radius: 12px;
   /* box-shadow: 0 4px 24px #0006; */
 }
@@ -222,9 +215,9 @@ nav {
   min-width: 0;
   padding: 0.5em 2.2em 0.5em 1em;
   border-radius: 6px;
-  border: 1px solid var(--accent-faded);
-  background: var(--bg-dark);
-  color: var(--fg-bright);
+  border: 1px solid var(--accent-40);
+  background: var(--ph-0);
+  color: var(--fg);
   font-family: "Fira Code", monospace;
   box-sizing: border-box;
 }
@@ -234,7 +227,7 @@ nav {
   right: 0.4em;
   background: none;
   border: none;
-  color: var(--accent-faded);
+  color: var(--accent-40);
   font-size: 1.2em;
   line-height: 1;
   cursor: pointer;
@@ -248,7 +241,7 @@ nav {
 
 .unread-notification {
   background: var(--accent);
-  color: var(--bg-dark);
+  color: var(--ph-0);
   padding: 0.3em 0.7em;
   border-radius: 3px;
   margin-left: 0.5em;
@@ -266,7 +259,7 @@ nav {
   overflow-y: auto;
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
-  scrollbar-color: var(--accent-faded) transparent;
+  scrollbar-color: var(--accent-40) transparent;
   margin-bottom: 1em;
 }
 
@@ -295,7 +288,7 @@ nav {
 
 .share-btn {
   background: none;
-  border: 1px solid var(--accent-faded, rgba(57,255,20,0.4));
+  border: 1px solid var(--accent-40, rgba(57,255,20,0.4));
   color: var(--accent, #39ff14);
   font-family: "Fira Code", monospace;
   font-size: 0.85em;
@@ -306,7 +299,7 @@ nav {
 }
 
 .share-btn:hover {
-  background: var(--accent-faded, rgba(57,255,20,0.12));
+  background: var(--accent-40, rgba(57,255,20,0.12));
 }
 
 /* Scroll-to-top button */
@@ -316,8 +309,8 @@ nav {
   right: 1.5rem;
   width: 2.4rem;
   height: 2.4rem;
-  background: var(--bg-darker, #0a0b0e);
-  border: 1px solid var(--accent-faded, rgba(57,255,20,0.4));
+  background: var(--ph-1, #0a0b0e);
+  border: 1px solid var(--accent-40, rgba(57,255,20,0.4));
   color: var(--accent, #39ff14);
   font-size: 1.1rem;
   border-radius: 50%;
@@ -341,14 +334,14 @@ nav {
   display: flex;
   justify-content: space-between;
   margin-bottom: 1em;
-  border: 1px solid var(--accent-faded);
+  border: 1px solid var(--accent-40);
   border-radius: 6px;
 }
 
 .post-nav span {
   /* Invisible placeholder to keep spacing */
   text-align: center;
-  color: var(--accent-faded);
+  color: var(--accent-40);
   padding: 0.3em 0.7em;
   margin: 0.2em 0;
   opacity: 0.5;
@@ -381,7 +374,7 @@ nav {
 }
 
 .pagination-controls button:disabled {
-  color: var(--accent-faded);
+  color: var(--accent-40);
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -397,7 +390,7 @@ nav {
 .load-more-indicator {
   padding: 0.75em;
   text-align: center;
-  color: var(--accent-faded);
+  color: var(--accent-40);
   font-size: 0.95em;
 }
 
@@ -432,7 +425,7 @@ nav {
 /*
 .post .post-meta {
     padding-bottom: 0.6em;
-    border-bottom: 1px solid var(--accent-faded);
+    border-bottom: 1px solid var(--accent-40);
 */
 
 .post-preview {
@@ -533,7 +526,7 @@ nav {
 
 .notification {
   background: var(--accent);
-  color: var(--bg-dark);
+  color: var(--ph-0);
   text-align: center;
   padding: 0.5em 1em;
   border-radius: 6px;
@@ -585,7 +578,7 @@ nav {
 }
 
 .footer-icon:hover svg {
-  color: var(--fg-bright);
+  color: var(--fg);
 }
 
 .footer-copyright {
@@ -728,7 +721,7 @@ nav {
 }
 
 .recent-post-item a {
-  color: var(--fg-bright, #d6f5e3);
+  color: var(--fg, #d6f5e3);
   text-decoration: none;
 }
 
@@ -828,7 +821,7 @@ nav {
 #boot-overlay {
   position: fixed;
   inset: 0;
-  background: var(--bg-dark, #101216);
+  background: var(--ph-0, #101216);
   z-index: 10000;
   display: flex;
   align-items: center;
@@ -884,21 +877,21 @@ nav {
   align-items: center;
   gap: 0.5em;
   padding: 0.75em 0;
-  border-top: 1px solid var(--accent-faded);
+  border-top: 1px solid var(--accent-40);
   flex-wrap: wrap;
 }
 
 .reactions-label {
   font-size: 0.82em;
-  color: var(--accent-faded);
+  color: var(--accent-40);
   font-family: "Fira Code", monospace;
   margin-right: 0.15em;
 }
 
 .reaction-btn {
   background: none;
-  border: 1px solid var(--accent-faded);
-  color: var(--fg-bright);
+  border: 1px solid var(--accent-40);
+  color: var(--fg);
   font-size: 0.9em;
   padding: 0.25em 0.65em;
   border-radius: 12px;
@@ -918,7 +911,7 @@ nav {
 .reaction-btn.reaction-picked {
   border-color: var(--accent);
   background: rgba(57, 255, 20, 0.14);
-  box-shadow: 0 0 6px var(--accent-faded);
+  box-shadow: 0 0 6px var(--accent-40);
 }
 
 .reaction-count {
@@ -945,10 +938,10 @@ nav {
 
 .reaction-input {
   width: 3em;
-  background: var(--bg-dark);
+  background: var(--ph-0);
   border: 1px solid var(--accent);
   border-radius: 8px;
-  color: var(--fg-bright);
+  color: var(--fg);
   font-size: 1em;
   padding: 0.15em 0.35em;
   text-align: center;
@@ -959,7 +952,7 @@ nav {
 .reaction-input-cancel {
   background: none;
   border: none;
-  color: var(--accent-faded);
+  color: var(--accent-40);
   font-size: 0.9em;
   cursor: pointer;
   padding: 0.1em 0.25em;
@@ -979,11 +972,11 @@ nav {
 #sticky-title-bar {
   position: sticky;
   top: 0;
-  background: var(--bg-darker);
+  background: var(--ph-1);
   color: var(--accent);
   font-family: "Fira Code", monospace;
   font-size: 0.82em;
-  border-bottom: 1px solid var(--accent-faded);
+  border-bottom: 1px solid var(--accent-40);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/css/travel.css
+++ b/css/travel.css
@@ -22,7 +22,7 @@
   right: 0;
   bottom: 0;
   min-height: 400px;
-  background: var(--bg-darker, #0a0b0e);
+  background: var(--ph-1, #0a0b0e);
 }
 
 .travel-map-fallback {
@@ -30,7 +30,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  color: var(--fg-bright);
+  color: var(--fg);
   font-family: "Fira Code", monospace;
   text-align: center;
   padding: 2em;
@@ -56,7 +56,7 @@
 .travel-subtitle {
   margin: 0.25rem 0 0;
   font-size: 0.75rem;
-  color: var(--fg-bright, #d6f5e3);
+  color: var(--fg, #d6f5e3);
   opacity: 0.8;
 }
 
@@ -95,15 +95,15 @@
 
 /* Leaflet overrides: match dark theme */
 .travel-map .leaflet-popup-content-wrapper {
-  background: var(--bg-darker, #0a0b0e);
-  color: var(--fg-bright, #d6f5e3);
-  border: 1px solid var(--accent-faded, rgba(57, 255, 20, 0.4));
+  background: var(--ph-1, #0a0b0e);
+  color: var(--fg, #d6f5e3);
+  border: 1px solid var(--accent-40, rgba(57, 255, 20, 0.4));
   border-radius: 4px;
   box-shadow: 0 0 16px rgba(57, 255, 20, 0.15);
 }
 
 .travel-map .leaflet-popup-tip {
-  background: var(--bg-darker, #0a0b0e);
+  background: var(--ph-1, #0a0b0e);
 }
 
 .travel-map .leaflet-popup-content {
@@ -143,30 +143,30 @@
 
 /* Zoom control dark */
 .travel-map .leaflet-control-zoom {
-  border: 1px solid var(--accent-faded) !important;
+  border: 1px solid var(--accent-40) !important;
   border-radius: 4px;
   overflow: hidden;
 }
 
 .travel-map .leaflet-control-zoom a {
-  background: var(--bg-darker) !important;
+  background: var(--ph-1) !important;
   color: var(--accent) !important;
   font-family: "Fira Code", monospace;
 }
 
 .travel-map .leaflet-control-zoom a:hover {
-  background: var(--accent-faded) !important;
-  color: var(--bg-dark) !important;
+  background: var(--accent-40) !important;
+  color: var(--ph-0) !important;
 }
 
 /* Marker cluster: dark theme + accent */
 .travel-map .marker-cluster {
   background: rgba(57, 255, 20, 0.2);
-  border: 1px solid var(--accent-faded, rgba(57, 255, 20, 0.5));
+  border: 1px solid var(--accent-40, rgba(57, 255, 20, 0.5));
 }
 .travel-map .marker-cluster div {
   background: var(--accent, #39ff14);
-  color: var(--bg-dark, #0a0b0e);
+  color: var(--ph-0, #0a0b0e);
   font-family: "Fira Code", monospace;
   font-weight: 700;
 }

--- a/stats.html
+++ b/stats.html
@@ -64,7 +64,7 @@
         color: var(--fg-dim, #888);
         margin-bottom: 1.8em;
         line-height: 2;
-        border-left: 2px solid var(--accent-faded, rgba(57, 255, 20, 0.25));
+        border-left: 2px solid var(--accent-40, rgba(57, 255, 20, 0.25));
         padding-left: 1em;
       }
 
@@ -85,7 +85,7 @@
       .stats-table thead th {
         text-align: left;
         padding: 0.4em 0.7em;
-        border-bottom: 1px solid var(--accent-faded, rgba(57, 255, 20, 0.3));
+        border-bottom: 1px solid var(--accent-40, rgba(57, 255, 20, 0.3));
         color: var(--accent, #39ff14);
         white-space: nowrap;
         user-select: none;


### PR DESCRIPTION
Mechanical: every remaining use of the four deprecated aliases replaced with its exact target token (same computed values — rendering unchanged by construction), then the alias block deleted as its own comment requested. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh