### PR TITLE
Clickable command mentions + drop the home tagline

### DIFF
--- a/css/terminal.css
+++ b/css/terminal.css
@@ -104,14 +104,6 @@
   background: var(--accent-15);
 }
 
-/* Home layout bits */
-.home-main .term-heading {
-  margin: 0 0 0.75em;
-  font-size: 1.1rem;
-  color: var(--fg-dim);
-  font-weight: normal;
-}
-
 @media (max-width: 700px) {
   .term {
     min-height: 200px;
@@ -204,4 +196,14 @@ a.term-motd-value:hover {
 
 .term-cat-body code {
   color: var(--amber);
+}
+
+/* Clickable command mentions */
+.term-cmd {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.term-cmd:hover {
+  text-decoration: underline;
 }

--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
         <button class="toggle-crt" onclick="toggleCrt()">Toggle screen effect</button>
       </aside>
       <main class="main-content home-main">
-        <p class="term-heading">// a terminal that is also a travel journal</p>
         <div id="terminal" class="term" aria-label="interactive terminal">
           <!-- Static fallback, replaced when terminal.js runs -->
           <div class="term-line">welcome!</div>

--- a/js/projects-terminal.js
+++ b/js/projects-terminal.js
@@ -161,7 +161,7 @@
   function cat(slug) {
     var p = bySlug[slug];
     if (!p) {
-      line("cat: " + escapeHtml(slug) + ": no such project — try <span class='term-accent'>ls</span>", "term-err");
+      line("cat: " + escapeHtml(slug) + ": no such project — try " + term.cmd("ls"), "term-err");
       return;
     }
     line("<span class='term-accent'>" + escapeHtml(p.name) + "</span> <span class='term-dim'>(" + escapeHtml(p.lang || "") + (p.year ? " · " + p.year : "") + ")</span>");
@@ -190,7 +190,7 @@
           ["clear", "wipe the screen"],
           ["cd ..", "back to the home terminal"],
         ].forEach(function (c) {
-          line("&nbsp;&nbsp;<span class='term-accent'>" + c[0] + "</span>&nbsp;&mdash; " + c[1], "term-dim");
+          line("&nbsp;&nbsp;" + term.cmd(c[0].split(" ")[0], c[0]) + "&nbsp;&mdash; " + c[1], "term-dim");
         });
       },
     },
@@ -198,7 +198,7 @@
     cat: {
       desc: "",
       run: function (args) {
-        if (!args.length) { line("usage: cat &lt;name&gt; — try <span class='term-accent'>ls</span>", "term-dim"); return; }
+        if (!args.length) { line("usage: cat &lt;name&gt; — try " + term.cmd("ls") + "", "term-dim"); return; }
         cat(args[0].replace(/\/$/, "").toLowerCase());
       },
     },
@@ -248,7 +248,7 @@
     } else if (bySlug[name]) {
       cat(name);
     } else {
-      line("command not found: " + escapeHtml(name) + " — try <span class='term-accent'>help</span>", "term-err");
+      line("command not found: " + escapeHtml(name) + " — try " + term.cmd("help") + "", "term-err");
     }
   }
 
@@ -257,7 +257,7 @@
     var bootCmd = "ls -la ~/projects";
     if (term.reducedMotion) {
       term.run(bootCmd);
-      line("click a project, or type <span class='term-accent'>help</span>.", "term-dim");
+      line("click a project, or type " + term.cmd("help") + ".", "term-dim");
       return;
     }
     var i = 0;
@@ -268,7 +268,7 @@
         setTimeout(function () {
           term.input.value = "";
           term.run(bootCmd);
-          line("click a project, or type <span class='term-accent'>help</span>.", "term-dim");
+          line("click a project, or type " + term.cmd("help") + ".", "term-dim");
         }, 250);
       }
     }, 40);

--- a/js/term-core.js
+++ b/js/term-core.js
@@ -50,6 +50,14 @@
       if (!window.getSelection || String(window.getSelection()) === "") input.focus();
     });
 
+    // Any highlighted command mention (term.cmd(...)) runs on click
+    scrollback.addEventListener("click", function (e) {
+      var el = e.target && e.target.closest ? e.target.closest(".term-cmd") : null;
+      if (!el) return;
+      e.preventDefault();
+      run(el.getAttribute("data-cmd") || "");
+    });
+
     function escapeHtml(s) {
       return s
         .replace(/&/g, "&amp;")
@@ -105,10 +113,22 @@
       }
     });
 
+    // A clickable command mention: renders accent, runs itself on click
+    function cmd(name, label) {
+      return (
+        "<a href='#' class='term-accent term-cmd' data-cmd='" +
+        escapeHtml(name) +
+        "'>" +
+        escapeHtml(label || name) +
+        "</a>"
+      );
+    }
+
     var term = {
       line: line,
       echo: echo,
       run: run,
+      cmd: cmd,
       escapeHtml: escapeHtml,
       clear: function () { scrollback.innerHTML = ""; },
       focus: function () { input.focus(); },

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -69,10 +69,7 @@
         Object.keys(COMMANDS).forEach(function (name) {
           if (COMMANDS[name].hidden) return;
           line(
-            "&nbsp;&nbsp;<span class='term-accent'>" +
-              name +
-              "</span>&nbsp;&mdash; " +
-              COMMANDS[name].desc,
+            "&nbsp;&nbsp;" + term.cmd(name) + "&nbsp;&mdash; " + COMMANDS[name].desc,
             "term-dim"
           );
         });
@@ -105,7 +102,7 @@
           navigate(target);
           return;
         }
-        line("cd: no such directory: " + escapeHtml(target) + " — try <span class='term-accent'>ls</span>", "term-err");
+        line("cd: no such directory: " + escapeHtml(target) + " — try " + term.cmd("ls"), "term-err");
       },
     },
     whoami: {
@@ -273,7 +270,7 @@
       line(
         "command not found: " +
           escapeHtml(name) +
-          " — try <span class='term-accent'>help</span>",
+          " — try " + term.cmd("help"),
         "term-err"
       );
     }
@@ -296,7 +293,7 @@
   }
 
   // Greeting
-  line("type <span class='term-accent'>help</span> to get started.", "term-dim");
+  line("type " + term.cmd("help") + " to get started.", "term-dim");
 
   // Autofocus on non-touch screens only (don't pop the mobile keyboard)
   if (window.matchMedia && window.matchMedia("(hover: hover)").matches) {

--- a/tests/smoke/home.spec.js
+++ b/tests/smoke/home.spec.js
@@ -22,6 +22,9 @@ test("home terminal responds to commands", async ({ page }) => {
   await expect(page.locator(".term-scrollback")).toContainText("this is the top");
   await type("cd nosuchpage");
   await expect(page.locator(".term-line.term-err").last()).toContainText("cd: no such directory: nosuchpage");
+  // Highlighted command mentions are clickable (e.g. `ls` in the cd error)
+  await page.locator(".term-cmd", { hasText: "ls" }).last().click();
+  await expect(page.locator(".term-dir")).toHaveCount(10); // second ls output
   expect(errors).toEqual([]);
 });
 


### PR DESCRIPTION
- New `term.cmd(name)` in term-core renders any command mention as a link that runs itself on click (one delegated scrollback handler). Applied to the greeting, both help listings, and every "try X" error hint in both terminals.
- The `// a terminal that is also a travel journal` heading is gone.

Suite: 15 passed, including a click-the-ls-mention assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh