### PR TITLE
Site-wide command palette (Ctrl+K)

### DIFF
--- a/404.html
+++ b/404.html
@@ -70,6 +70,9 @@
     </div>
     <footer></footer>
     <script src="/js/include-components.js"></script>
+    <script src="/js/term-core.js"></script>
+    <script src="/js/now-data.js"></script>
+    <script src="/js/term-overlay.js"></script>
     <script src="/js/main.js"></script>
   </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -18,6 +18,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="css/terminal.css" />
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="alternate" type="application/rss+xml" title="tbd RSS Feed" href="/feed.xml" />
     <script src="js/vendor/marked.min.js"></script>
@@ -67,6 +68,9 @@
     <footer></footer>
     <script src="js/main.js"></script>
     <script src="js/include-components.js"></script>
+    <script src="js/term-core.js"></script>
+    <script src="js/now-data.js"></script>
+    <script src="js/term-overlay.js"></script>
     <script src="js/reactions.js"></script>
     <script src="js/view-counter.js"></script>
     <script src="js/notifications.js" defer></script>

--- a/components/header.html
+++ b/components/header.html
@@ -10,5 +10,6 @@
     <li><a href="blog">Blog</a></li>
     <li><a href="music">Music</a></li>
     <li><a href="projects">Projects</a></li>
+    <li><button type="button" class="nav-term-btn" title="command palette (ctrl+k)" aria-label="open command palette">&gt;_</button></li>
   </ul>
 </nav>

--- a/css/terminal.css
+++ b/css/terminal.css
@@ -207,3 +207,51 @@ a.term-motd-value:hover {
 .term-cmd:hover {
   text-decoration: underline;
 }
+
+/* Site-wide command palette (Ctrl/Cmd+K) */
+.term-overlay-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 5, 7, 0.75);
+  z-index: 2000;
+}
+
+.term-overlay-backdrop.open {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 12vh 1em 0;
+}
+
+.term-overlay {
+  width: 100%;
+  max-width: 640px;
+  max-height: 60vh;
+  min-height: 0;
+  box-shadow: 0 0 24px var(--accent-15), 0 12px 48px rgba(0, 0, 0, 0.6);
+  animation: palette-in 0.12s ease-out;
+}
+
+@keyframes palette-in {
+  from { transform: translateY(-8px); opacity: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .term-overlay { animation: none; }
+}
+
+.nav-term-btn {
+  background: none;
+  border: 1px solid var(--accent-40);
+  color: var(--accent);
+  font-family: "Fira Code", monospace;
+  font-size: 0.85em;
+  border-radius: 4px;
+  padding: 0.15em 0.5em;
+  cursor: pointer;
+}
+
+.nav-term-btn:hover {
+  background: var(--accent-15);
+}

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <script src="js/now-data.js"></script>
     <script src="js/terminal.js"></script>
     <script src="js/motd.js"></script>
+    <script src="js/term-overlay.js"></script>
     <script src="js/recent-posts.js"></script>
   </body>
 </html>

--- a/js/term-overlay.js
+++ b/js/term-overlay.js
@@ -1,0 +1,180 @@
+// Site-wide terminal palette: Ctrl/Cmd+K (or the >_ nav button) summons a
+// terminal overlay on any page — cd navigation, grep post search, now
+// status, crt toggle. Esc closes. Built on js/term-core.js.
+(function () {
+  if (!window.TbdTerm) return;
+
+  var PAGES = ["blog", "travel", "music", "projects", "stats"];
+  var backdrop = null;
+  var term = null;
+  var postsIndex = null;
+
+  function withPosts(fn) {
+    if (postsIndex) return fn(postsIndex);
+    fetch("posts/index.json")
+      .then(function (r) { return r.ok ? r.json() : []; })
+      .then(function (posts) { postsIndex = posts; fn(posts); })
+      .catch(function () { fn([]); });
+  }
+
+  function navigate(page) {
+    term.line("opening " + page + "…", "term-dim");
+    close();
+    window.location.href = page;
+  }
+
+  function grep(query, line) {
+    if (!query) {
+      line("usage: grep &lt;query&gt; — searches the posts", "term-dim");
+      return;
+    }
+    withPosts(function (posts) {
+      var q = query.toLowerCase();
+      var hits = posts.filter(function (p) {
+        return (
+          (p.title || "").toLowerCase().indexOf(q) >= 0 ||
+          (p.preview || "").toLowerCase().indexOf(q) >= 0 ||
+          (p.categories || []).join(" ").toLowerCase().indexOf(q) >= 0
+        );
+      });
+      if (!hits.length) {
+        line("grep: no matches for " + term.escapeHtml(query), "term-dim");
+        return;
+      }
+      line(hits.length + (hits.length === 1 ? " match:" : " matches:"), "term-dim");
+      hits.slice(0, 8).forEach(function (p) {
+        var el = term.line("", "term-grep-hit");
+        var date = document.createElement("span");
+        date.className = "term-dim";
+        date.textContent = (p.date || "").split(" ")[0] + "  ";
+        var a = document.createElement("a");
+        a.className = "term-accent";
+        a.href = "blog?post=" + encodeURIComponent(p.filename);
+        var bdi = document.createElement("bdi");
+        bdi.textContent = p.title || p.filename;
+        a.appendChild(bdi);
+        el.appendChild(date);
+        el.appendChild(a);
+      });
+      if (hits.length > 8) line("… and " + (hits.length - 8) + " more", "term-dim");
+    });
+  }
+
+  function exec(cmd) {
+    var line = term.line;
+    var parts = cmd.split(/\s+/);
+    var name = parts[0].toLowerCase();
+    var args = parts.slice(1);
+
+    if (name === "cd") {
+      var target = (args[0] || "").replace(/\/$/, "").toLowerCase();
+      if (!target || target === "~") { navigate("./"); return; }
+      if (target === "..") { line("this is the top.", "term-dim"); return; }
+      if (PAGES.indexOf(target) >= 0) { navigate(target); return; }
+      line("cd: no such directory: " + term.escapeHtml(target) + " — try " + term.cmd("ls"), "term-err");
+      return;
+    }
+    if (name === "ls") {
+      line(PAGES.map(function (p) {
+        return "<a href='" + p + "' class='term-dir'>" + p + "/</a>";
+      }).join("&nbsp;&nbsp;"));
+      return;
+    }
+    if (name === "grep" || name === "find" || name === "search") {
+      grep(args.join(" "), line);
+      return;
+    }
+    if (name === "now") {
+      if (!window.TbdNow) { line("now: status unavailable", "term-err"); return; }
+      line("checking…", "term-dim");
+      window.TbdNow.fetch().then(function (data) {
+        var lines = window.TbdNow.lines(data);
+        if (!lines.length) { line("all quiet.", "term-dim"); return; }
+        lines.forEach(function (l) {
+          var value = l.url
+            ? "<a href='" + term.escapeHtml(l.url) + "' class='term-accent'><bdi>" + term.escapeHtml(l.text) + "</bdi></a>"
+            : "<bdi>" + term.escapeHtml(l.text) + "</bdi>";
+          line("<span class='term-dim'>" + term.escapeHtml(l.label) + ":</span> " + value);
+        });
+      });
+      return;
+    }
+    if (name === "crt") {
+      if (typeof window.toggleCrt === "function") {
+        window.toggleCrt();
+        line(document.body.classList.contains("crt") ? "crt on." : "crt off.");
+      } else {
+        line("crt: effect unavailable", "term-err");
+      }
+      return;
+    }
+    if (name === "clear") { term.clear(); return; }
+    if (name === "exit" || name === "q" || name === ":q") { close(); return; }
+    if (name === "help") {
+      line("the palette:");
+      [
+        ["cd blog", "go somewhere (also: ls)"],
+        ["grep osaka", "search the posts"],
+        ["now", "what's happening"],
+        ["crt", "toggle the screen effect"],
+        ["exit", "close (or esc)"],
+      ].forEach(function (c) {
+        term.line("&nbsp;&nbsp;" + term.cmd(c[0]) + "&nbsp;&mdash; " + c[1], "term-dim");
+      });
+      return;
+    }
+    if (PAGES.indexOf(name.replace(/\/$/, "")) >= 0) { navigate(name.replace(/\/$/, "")); return; }
+    line("command not found: " + term.escapeHtml(name) + " — try " + term.cmd("help"), "term-err");
+  }
+
+  function build() {
+    backdrop = document.createElement("div");
+    backdrop.className = "term-overlay-backdrop";
+    var panel = document.createElement("div");
+    panel.className = "term term-overlay";
+    panel.setAttribute("role", "dialog");
+    panel.setAttribute("aria-modal", "true");
+    panel.setAttribute("aria-label", "command palette");
+    backdrop.appendChild(panel);
+    document.body.appendChild(backdrop);
+    backdrop.addEventListener("click", function (e) {
+      if (e.target === backdrop) close();
+    });
+    term = window.TbdTerm(panel, { path: "~", exec: exec });
+    term.line("try " + term.cmd("grep music", "grep <query>") + ", " + term.cmd("cd travel") + ", or " + term.cmd("now") + ". esc closes.", "term-dim");
+  }
+
+  function open() {
+    if (!backdrop) build();
+    backdrop.classList.add("open");
+    term.focus();
+  }
+
+  function close() {
+    if (backdrop) backdrop.classList.remove("open");
+  }
+
+  function isOpen() {
+    return !!(backdrop && backdrop.classList.contains("open"));
+  }
+
+  document.addEventListener("keydown", function (e) {
+    if ((e.ctrlKey || e.metaKey) && (e.key === "k" || e.key === "K")) {
+      e.preventDefault();
+      if (isOpen()) close(); else open();
+      return;
+    }
+    if (e.key === "Escape" && isOpen()) {
+      e.preventDefault();
+      close();
+    }
+  });
+
+  // The >_ button lives in the injected header — delegate
+  document.addEventListener("click", function (e) {
+    var btn = e.target && e.target.closest ? e.target.closest(".nav-term-btn") : null;
+    if (!btn) return;
+    e.preventDefault();
+    if (isOpen()) close(); else open();
+  });
+})();

--- a/music.html
+++ b/music.html
@@ -9,6 +9,7 @@
     <meta property="og:url" content="https://tbd.codes/music" />
     <meta name="twitter:card" content="summary" />
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="css/terminal.css" />
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="alternate" type="application/rss+xml" title="tbd RSS Feed" href="/feed.xml" />
     <link
@@ -38,6 +39,9 @@
     </div>
     <footer></footer>
     <script src="js/include-components.js"></script>
+    <script src="js/term-core.js"></script>
+    <script src="js/now-data.js"></script>
+    <script src="js/term-overlay.js"></script>
     <script src="js/main.js"></script>
     <script src="js/music.js"></script>
     <script src="js/music-shelf.js"></script>

--- a/projects.html
+++ b/projects.html
@@ -34,6 +34,8 @@
     <script src="js/include-components.js"></script>
     <script src="js/main.js"></script>
     <script src="js/term-core.js"></script>
+    <script src="js/now-data.js"></script>
+    <script src="js/term-overlay.js"></script>
     <script src="js/projects-terminal.js"></script>
   </body>
 </html>

--- a/tests/smoke/overlay.spec.js
+++ b/tests/smoke/overlay.spec.js
@@ -1,0 +1,45 @@
+const { test, expect } = require("@playwright/test");
+const { phosphorPage } = require("../helpers");
+
+test("Ctrl+K palette: search, navigate-errors, esc", async ({ page, request }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());
+  const index = await (await request.get("/posts/index.json")).json();
+  const word = (index[0].title || index[0].filename).split(/\s+/)[0];
+
+  await page.goto("/travel.html", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("header nav", { timeout: 10000 });
+
+  await page.keyboard.press("Control+k");
+  await expect(page.locator(".term-overlay-backdrop")).toHaveClass(/open/);
+
+  const type = async (cmd) => {
+    await page.fill(".term-overlay .term-input", cmd);
+    await page.press(".term-overlay .term-input", "Enter");
+  };
+  await type("grep " + word);
+  await expect(page.locator(".term-grep-hit").first()).toBeVisible();
+  await expect(page.locator(".term-grep-hit a").first()).toHaveAttribute("href", /blog\?post=/);
+
+  await type("cd nosuchpage");
+  await expect(page.locator(".term-overlay .term-line.term-err").last()).toContainText("cd: no such directory");
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".term-overlay-backdrop")).not.toHaveClass(/open/);
+  expect(errors).toEqual([]);
+});
+
+test("the >_ nav button opens the palette on every page", async ({ page }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());
+  await page.route("https://api.github.com/repos/**", (r) => r.fulfill({ json: {} }));
+  await page.route("https://raw.githubusercontent.com/**", (r) => r.abort());
+  for (const path of ["/", "/blog.html", "/music.html", "/projects.html"]) {
+    await page.goto(path, { waitUntil: "domcontentloaded" });
+    await page.waitForSelector(".nav-term-btn", { timeout: 10000 });
+    await page.click(".nav-term-btn");
+    await expect(page.locator(".term-overlay-backdrop")).toHaveClass(/open/);
+    await page.keyboard.press("Escape");
+  }
+  expect(errors).toEqual([]);
+});

--- a/travel.html
+++ b/travel.html
@@ -9,6 +9,7 @@
     <meta property="og:url" content="https://tbd.codes/travel" />
     <meta name="twitter:card" content="summary" />
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="css/terminal.css" />
     <link rel="stylesheet" href="css/travel.css" />
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="alternate" type="application/rss+xml" title="tbd RSS Feed" href="/feed.xml" />
@@ -35,6 +36,9 @@
     <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js" integrity="sha384-eXVCORTRlv4FUUgS/xmOyr66XBVraen8ATNLMESp92FKXLAMiKkerixTiBvXriZr" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/leaflet-ant-path@1.3.0/dist/leaflet-ant-path.js" integrity="sha384-OEj5w5dYIX4MUvZAeaQ/7L8HGNi6Qtb54Yl6dY1sUQyUiOuxeUznR8DOvAWHGpOx" crossorigin="anonymous"></script>
     <script src="js/include-components.js"></script>
+    <script src="js/term-core.js"></script>
+    <script src="js/now-data.js"></script>
+    <script src="js/term-overlay.js"></script>
     <script src="js/main.js"></script>
     <script src="js/travel.js"></script>
   </body>


### PR DESCRIPTION
The "go bigger" piece: the terminal becomes how you get around the site.

- **Ctrl/Cmd+K anywhere** (or the `>_` button now in the nav) opens a terminal overlay — dimmed backdrop, lazy-built DOM, esc/backdrop-click/`exit` closes
- **`grep <query>`** searches all posts by title/preview/category, printing dated clickable results (deep links to the post) — search from any page is the point
- `cd <page>`/`ls` navigation (same semantics as home), `now` status, `crt` toggle, clickable command mentions throughout
- Reuses `js/term-core.js`; wired on all five pages + 404

Suite: 17 passed (palette search/esc + nav-button-on-every-page specs added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh