### PR TITLE
Shared terminal command set — grep everywhere, ls first in greeting

### DIFF
--- a/404.html
+++ b/404.html
@@ -71,6 +71,7 @@
     <footer></footer>
     <script src="/js/include-components.js"></script>
     <script src="/js/term-core.js"></script>
+    <script src="/js/term-commands.js"></script>
     <script src="/js/now-data.js"></script>
     <script src="/js/term-overlay.js"></script>
     <script src="/js/main.js"></script>

--- a/blog.html
+++ b/blog.html
@@ -69,6 +69,7 @@
     <script src="js/main.js"></script>
     <script src="js/include-components.js"></script>
     <script src="js/term-core.js"></script>
+    <script src="js/term-commands.js"></script>
     <script src="js/now-data.js"></script>
     <script src="js/term-overlay.js"></script>
     <script src="js/reactions.js"></script>

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
     <script src="js/main.js"></script>
     <script src="js/index-redirect.js"></script>
     <script src="js/term-core.js"></script>
+    <script src="js/term-commands.js"></script>
     <script src="js/now-data.js"></script>
     <script src="js/terminal.js"></script>
     <script src="js/motd.js"></script>

--- a/js/term-commands.js
+++ b/js/term-commands.js
@@ -1,0 +1,141 @@
+// Shared command set for the tbd.codes terminals (home page + the Ctrl+K
+// palette): navigation, post search, status, screen effect. Each terminal
+// merges these into its own command map, so a command added here exists
+// everywhere at once.
+//
+// Usage: var common = TbdCommands.common(term, { navigate, isHome });
+// Commands are { desc, run(args) } — same shape the terminals already use.
+(function () {
+  var PAGES = ["blog", "travel", "music", "projects", "stats"];
+  var postsIndex = null; // one cache per page load, shared by both terminals
+
+  function withPosts(fn) {
+    if (postsIndex) return fn(postsIndex);
+    fetch("posts/index.json")
+      .then(function (r) { return r.ok ? r.json() : []; })
+      .then(function (posts) { postsIndex = posts; fn(posts); })
+      .catch(function () { fn([]); });
+  }
+
+  window.TbdCommands = {
+    PAGES: PAGES,
+
+    common: function (term, opts) {
+      var line = term.line;
+      var navigate = opts.navigate;
+
+      return {
+        ls: {
+          desc: "list what's here",
+          run: function () {
+            line(PAGES.map(function (p) {
+              return "<a href='" + p + "' class='term-dir'>" + p + "/</a>";
+            }).join("&nbsp;&nbsp;"));
+          },
+        },
+
+        cd: {
+          desc: "go somewhere — try cd blog",
+          run: function (args) {
+            var target = (args[0] || "").replace(/\/$/, "").toLowerCase();
+            if (!target || target === "~") {
+              if (opts.isHome) line("you're home.", "term-dim");
+              else navigate("./");
+              return;
+            }
+            if (target === "..") {
+              line("this is the top. there is no up from here.", "term-dim");
+              return;
+            }
+            if (PAGES.indexOf(target) >= 0) {
+              navigate(target);
+              return;
+            }
+            line("cd: no such directory: " + term.escapeHtml(target) + " — try " + term.cmd("ls"), "term-err");
+          },
+        },
+
+        grep: {
+          desc: "search the posts — try grep osaka",
+          run: function (args) {
+            var query = args.join(" ");
+            if (!query) {
+              line("usage: grep &lt;query&gt; — searches the posts", "term-dim");
+              return;
+            }
+            withPosts(function (posts) {
+              var q = query.toLowerCase();
+              var hits = posts.filter(function (p) {
+                return (
+                  (p.title || "").toLowerCase().indexOf(q) >= 0 ||
+                  (p.preview || "").toLowerCase().indexOf(q) >= 0 ||
+                  (p.categories || []).join(" ").toLowerCase().indexOf(q) >= 0
+                );
+              });
+              if (!hits.length) {
+                line("grep: no matches for " + term.escapeHtml(query), "term-dim");
+                return;
+              }
+              line(hits.length + (hits.length === 1 ? " match:" : " matches:"), "term-dim");
+              hits.slice(0, 8).forEach(function (p) {
+                var el = line("", "term-grep-hit");
+                var date = document.createElement("span");
+                date.className = "term-dim";
+                date.textContent = (p.date || "").split(" ")[0] + "  ";
+                var a = document.createElement("a");
+                a.className = "term-accent";
+                a.href = "blog?post=" + encodeURIComponent(p.filename);
+                var bdi = document.createElement("bdi");
+                bdi.textContent = p.title || p.filename;
+                a.appendChild(bdi);
+                el.appendChild(date);
+                el.appendChild(a);
+              });
+              if (hits.length > 8) line("… and " + (hits.length - 8) + " more", "term-dim");
+            });
+          },
+        },
+
+        now: {
+          desc: "what's happening",
+          run: function () {
+            if (!window.TbdNow) {
+              line("now: status unavailable", "term-err");
+              return;
+            }
+            line("checking…", "term-dim");
+            window.TbdNow.fetch().then(function (data) {
+              var lines = window.TbdNow.lines(data);
+              if (!lines.length) {
+                line("all quiet.", "term-dim");
+                return;
+              }
+              lines.forEach(function (l) {
+                var value = l.url
+                  ? "<a href='" + term.escapeHtml(l.url) + "' class='term-accent'><bdi>" + term.escapeHtml(l.text) + "</bdi></a>"
+                  : "<bdi>" + term.escapeHtml(l.text) + "</bdi>";
+                line("<span class='term-dim'>" + term.escapeHtml(l.label) + ":</span> " + value);
+              });
+            });
+          },
+        },
+
+        crt: {
+          desc: "toggle the screen effect",
+          run: function () {
+            if (typeof window.toggleCrt === "function") {
+              window.toggleCrt();
+              line(
+                document.body.classList.contains("crt")
+                  ? "crt on. easy on the eyes, hard on the pixels."
+                  : "crt off."
+              );
+            } else {
+              line("crt: effect unavailable", "term-err");
+            }
+          },
+        },
+      };
+    },
+  };
+})();

--- a/js/term-overlay.js
+++ b/js/term-overlay.js
@@ -1,21 +1,13 @@
 // Site-wide terminal palette: Ctrl/Cmd+K (or the >_ nav button) summons a
-// terminal overlay on any page — cd navigation, grep post search, now
-// status, crt toggle. Esc closes. Built on js/term-core.js.
+// terminal overlay on any page. Commands come from js/term-commands.js —
+// the same set the home terminal uses — plus palette-only exit/help.
 (function () {
-  if (!window.TbdTerm) return;
+  if (!window.TbdTerm || !window.TbdCommands) return;
 
-  var PAGES = ["blog", "travel", "music", "projects", "stats"];
+  var PAGES = window.TbdCommands.PAGES;
   var backdrop = null;
   var term = null;
-  var postsIndex = null;
-
-  function withPosts(fn) {
-    if (postsIndex) return fn(postsIndex);
-    fetch("posts/index.json")
-      .then(function (r) { return r.ok ? r.json() : []; })
-      .then(function (posts) { postsIndex = posts; fn(posts); })
-      .catch(function () { fn([]); });
-  }
+  var COMMANDS = null;
 
   function navigate(page) {
     term.line("opening " + page + "…", "term-dim");
@@ -23,108 +15,22 @@
     window.location.href = page;
   }
 
-  function grep(query, line) {
-    if (!query) {
-      line("usage: grep &lt;query&gt; — searches the posts", "term-dim");
-      return;
-    }
-    withPosts(function (posts) {
-      var q = query.toLowerCase();
-      var hits = posts.filter(function (p) {
-        return (
-          (p.title || "").toLowerCase().indexOf(q) >= 0 ||
-          (p.preview || "").toLowerCase().indexOf(q) >= 0 ||
-          (p.categories || []).join(" ").toLowerCase().indexOf(q) >= 0
-        );
-      });
-      if (!hits.length) {
-        line("grep: no matches for " + term.escapeHtml(query), "term-dim");
-        return;
-      }
-      line(hits.length + (hits.length === 1 ? " match:" : " matches:"), "term-dim");
-      hits.slice(0, 8).forEach(function (p) {
-        var el = term.line("", "term-grep-hit");
-        var date = document.createElement("span");
-        date.className = "term-dim";
-        date.textContent = (p.date || "").split(" ")[0] + "  ";
-        var a = document.createElement("a");
-        a.className = "term-accent";
-        a.href = "blog?post=" + encodeURIComponent(p.filename);
-        var bdi = document.createElement("bdi");
-        bdi.textContent = p.title || p.filename;
-        a.appendChild(bdi);
-        el.appendChild(date);
-        el.appendChild(a);
-      });
-      if (hits.length > 8) line("… and " + (hits.length - 8) + " more", "term-dim");
-    });
-  }
-
   function exec(cmd) {
-    var line = term.line;
     var parts = cmd.split(/\s+/);
     var name = parts[0].toLowerCase();
     var args = parts.slice(1);
 
-    if (name === "cd") {
-      var target = (args[0] || "").replace(/\/$/, "").toLowerCase();
-      if (!target || target === "~") { navigate("./"); return; }
-      if (target === "..") { line("this is the top.", "term-dim"); return; }
-      if (PAGES.indexOf(target) >= 0) { navigate(target); return; }
-      line("cd: no such directory: " + term.escapeHtml(target) + " — try " + term.cmd("ls"), "term-err");
-      return;
-    }
-    if (name === "ls") {
-      line(PAGES.map(function (p) {
-        return "<a href='" + p + "' class='term-dir'>" + p + "/</a>";
-      }).join("&nbsp;&nbsp;"));
-      return;
-    }
-    if (name === "grep" || name === "find" || name === "search") {
-      grep(args.join(" "), line);
-      return;
-    }
-    if (name === "now") {
-      if (!window.TbdNow) { line("now: status unavailable", "term-err"); return; }
-      line("checking…", "term-dim");
-      window.TbdNow.fetch().then(function (data) {
-        var lines = window.TbdNow.lines(data);
-        if (!lines.length) { line("all quiet.", "term-dim"); return; }
-        lines.forEach(function (l) {
-          var value = l.url
-            ? "<a href='" + term.escapeHtml(l.url) + "' class='term-accent'><bdi>" + term.escapeHtml(l.text) + "</bdi></a>"
-            : "<bdi>" + term.escapeHtml(l.text) + "</bdi>";
-          line("<span class='term-dim'>" + term.escapeHtml(l.label) + ":</span> " + value);
-        });
-      });
-      return;
-    }
-    if (name === "crt") {
-      if (typeof window.toggleCrt === "function") {
-        window.toggleCrt();
-        line(document.body.classList.contains("crt") ? "crt on." : "crt off.");
-      } else {
-        line("crt: effect unavailable", "term-err");
-      }
-      return;
-    }
-    if (name === "clear") { term.clear(); return; }
+    if (name === "find" || name === "search") name = "grep";
     if (name === "exit" || name === "q" || name === ":q") { close(); return; }
-    if (name === "help") {
-      line("the palette:");
-      [
-        ["cd blog", "go somewhere (also: ls)"],
-        ["grep osaka", "search the posts"],
-        ["now", "what's happening"],
-        ["crt", "toggle the screen effect"],
-        ["exit", "close (or esc)"],
-      ].forEach(function (c) {
-        term.line("&nbsp;&nbsp;" + term.cmd(c[0]) + "&nbsp;&mdash; " + c[1], "term-dim");
-      });
-      return;
+
+    var command = COMMANDS[name];
+    if (command) {
+      command.run(args);
+    } else if (PAGES.indexOf(name.replace(/\/$/, "")) >= 0) {
+      navigate(name.replace(/\/$/, ""));
+    } else {
+      term.line("command not found: " + term.escapeHtml(name) + " — try " + term.cmd("help"), "term-err");
     }
-    if (PAGES.indexOf(name.replace(/\/$/, "")) >= 0) { navigate(name.replace(/\/$/, "")); return; }
-    line("command not found: " + term.escapeHtml(name) + " — try " + term.cmd("help"), "term-err");
   }
 
   function build() {
@@ -140,8 +46,39 @@
     backdrop.addEventListener("click", function (e) {
       if (e.target === backdrop) close();
     });
+
     term = window.TbdTerm(panel, { path: "~", exec: exec });
-    term.line("try " + term.cmd("grep music", "grep <query>") + ", " + term.cmd("cd travel") + ", or " + term.cmd("now") + ". esc closes.", "term-dim");
+    var common = window.TbdCommands.common(term, { navigate: navigate, isHome: false });
+    COMMANDS = {
+      help: {
+        desc: "",
+        run: function () {
+          term.line("the palette:");
+          [
+            ["ls", "list the pages"],
+            ["cd blog", "go somewhere"],
+            ["grep osaka", "search the posts"],
+            ["now", "what's happening"],
+            ["crt", "toggle the screen effect"],
+            ["exit", "close (or esc)"],
+          ].forEach(function (c) {
+            term.line("&nbsp;&nbsp;" + term.cmd(c[0]) + "&nbsp;&mdash; " + c[1], "term-dim");
+          });
+        },
+      },
+      ls: common.ls,
+      cd: common.cd,
+      grep: common.grep,
+      now: common.now,
+      crt: common.crt,
+      clear: { desc: "", run: function () { term.clear(); } },
+    };
+
+    term.line(
+      "try " + term.cmd("ls") + ", " + term.cmd("cd travel") + ", " +
+        term.cmd("grep music", "grep <query>") + ", or " + term.cmd("now") + ". esc closes.",
+      "term-dim"
+    );
   }
 
   function open() {

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -4,9 +4,9 @@
 // already inside #terminal when JS is unavailable.
 (function () {
   var root = document.getElementById("terminal");
-  if (!root || !window.TbdTerm) return;
+  if (!root || !window.TbdTerm || !window.TbdCommands) return;
 
-  var PAGES = ["blog", "travel", "music", "projects", "stats"];
+  var PAGES = window.TbdCommands.PAGES;
   var postsIndex = null; // lazy-loaded for pwd/whoami
 
   var term = window.TbdTerm(root, { path: "~", exec: exec });
@@ -20,6 +20,9 @@
       window.location.href = page;
     }, reducedMotion ? 0 : 350);
   }
+
+  // Shared commands (ls/cd/grep/now/crt) — one definition for every terminal
+  var common = window.TbdCommands.common(term, { navigate: navigate, isHome: true });
 
   function latestTravelPost(posts) {
     var travel = posts.filter(function (p) {
@@ -76,35 +79,9 @@
         line("plus a few undocumented ones. it's a terminal, poke around.", "term-dim");
       },
     },
-    ls: {
-      desc: "list what's here",
-      run: function () {
-        line(
-          PAGES.map(function (p) {
-            return "<a href='" + p + "' class='term-dir'>" + p + "/</a>";
-          }).join("&nbsp;&nbsp;")
-        );
-      },
-    },
-    cd: {
-      desc: "go somewhere — try cd blog",
-      run: function (args) {
-        var target = (args[0] || "").replace(/\/$/, "").toLowerCase();
-        if (!target || target === "~") {
-          line("you're home.", "term-dim");
-          return;
-        }
-        if (target === "..") {
-          line("this is the top. there is no up from here.", "term-dim");
-          return;
-        }
-        if (PAGES.indexOf(target) >= 0) {
-          navigate(target);
-          return;
-        }
-        line("cd: no such directory: " + escapeHtml(target) + " — try " + term.cmd("ls"), "term-err");
-      },
-    },
+    ls: common.ls,
+    cd: common.cd,
+    grep: common.grep,
     whoami: {
       desc: "who is tbd anyway",
       run: function () {
@@ -122,29 +99,7 @@
         });
       },
     },
-    now: {
-      desc: "what's happening",
-      run: function () {
-        if (!window.TbdNow) {
-          line("now: status unavailable", "term-err");
-          return;
-        }
-        line("checking…", "term-dim");
-        window.TbdNow.fetch().then(function (data) {
-          var lines = window.TbdNow.lines(data);
-          if (!lines.length) {
-            line("all quiet.", "term-dim");
-            return;
-          }
-          lines.forEach(function (l) {
-            var value = l.url
-              ? "<a href='" + escapeHtml(l.url) + "' class='term-accent'><bdi>" + escapeHtml(l.text) + "</bdi></a>"
-              : "<bdi>" + escapeHtml(l.text) + "</bdi>";
-            line("<span class='term-dim'>" + escapeHtml(l.label) + ":</span> " + value);
-          });
-        });
-      },
-    },
+    now: common.now,
     pwd: {
       desc: "where am i",
       run: function () {
@@ -194,21 +149,7 @@
         term.clear();
       },
     },
-    crt: {
-      desc: "toggle the screen effect",
-      run: function () {
-        if (typeof window.toggleCrt === "function") {
-          window.toggleCrt();
-          line(
-            document.body.classList.contains("crt")
-              ? "crt on. easy on the eyes, hard on the pixels."
-              : "crt off."
-          );
-        } else {
-          line("crt: effect unavailable", "term-err");
-        }
-      },
-    },
+    crt: common.crt,
     sudo: {
       hidden: true,
       desc: "",

--- a/music.html
+++ b/music.html
@@ -40,6 +40,7 @@
     <footer></footer>
     <script src="js/include-components.js"></script>
     <script src="js/term-core.js"></script>
+    <script src="js/term-commands.js"></script>
     <script src="js/now-data.js"></script>
     <script src="js/term-overlay.js"></script>
     <script src="js/main.js"></script>

--- a/projects.html
+++ b/projects.html
@@ -34,6 +34,7 @@
     <script src="js/include-components.js"></script>
     <script src="js/main.js"></script>
     <script src="js/term-core.js"></script>
+    <script src="js/term-commands.js"></script>
     <script src="js/now-data.js"></script>
     <script src="js/term-overlay.js"></script>
     <script src="js/projects-terminal.js"></script>

--- a/tests/smoke/home.spec.js
+++ b/tests/smoke/home.spec.js
@@ -28,6 +28,20 @@ test("home terminal responds to commands", async ({ page }) => {
   expect(errors).toEqual([]);
 });
 
+test("grep works in the home terminal (shared command set)", async ({ page, request }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());
+  const index = await (await request.get("/posts/index.json")).json();
+  const word = (index[0].title || index[0].filename).split(/\s+/)[0];
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#term-input");
+  await page.fill("#term-input", "grep " + word);
+  await page.press("#term-input", "Enter");
+  await expect(page.locator(".term-grep-hit").first()).toBeVisible();
+  await expect(page.locator(".term-grep-hit a").first()).toHaveAttribute("href", /blog\?post=/);
+  expect(errors).toEqual([]);
+});
+
 test("MOTD strip and `now` command surface living signals", async ({ page }) => {
   const errors = await phosphorPage(page);
   await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) =>

--- a/travel.html
+++ b/travel.html
@@ -37,6 +37,7 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet-ant-path@1.3.0/dist/leaflet-ant-path.js" integrity="sha384-OEj5w5dYIX4MUvZAeaQ/7L8HGNi6Qtb54Yl6dY1sUQyUiOuxeUznR8DOvAWHGpOx" crossorigin="anonymous"></script>
     <script src="js/include-components.js"></script>
     <script src="js/term-core.js"></script>
+    <script src="js/term-commands.js"></script>
     <script src="js/now-data.js"></script>
     <script src="js/term-overlay.js"></script>
     <script src="js/main.js"></script>


### PR DESCRIPTION
Tomer's catch: the home terminal didn't have `grep` because the two terminals duplicated their command sets. Fixed at the root:

- **`js/term-commands.js`**: one definition of `ls`/`cd`/`grep`/`now`/`crt` (with a shared per-page posts cache); the home terminal and the palette merge it and keep only their own extras (whoami/pwd/meltdown vs exit). A command added here now exists everywhere at once.
- Home terminal gains `grep` (documented in its help).
- Palette greeting reordered: `ls` before `cd travel`.

Suite: 18 passed (new home-grep spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh