### PR TITLE
Bootloader hold in the meltdown recovery; randomized ping

### DIFF
--- a/css/terminal.css
+++ b/css/terminal.css
@@ -304,3 +304,11 @@ body.melting {
   body.melting { animation: none; }
   .meltdown-blackout { transition: none; }
 }
+
+.meltdown-continue {
+  color: var(--fg-dim);
+}
+
+.meltdown-blink {
+  animation: blink-cursor 1s steps(2, start) infinite;
+}

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -188,8 +188,18 @@
       hidden: true,
       desc: "",
       run: function (args) {
-        var host = args[0] || "tbd.codes";
-        line("PING " + escapeHtml(host) + ": 64 bytes, 12ms. it's alive.", "term-dim");
+        var host = escapeHtml(args[0] || "tbd.codes");
+        var roll = Math.random();
+        if (roll < 0.07) {
+          line("PING " + host + ": request timed out. probably fine.", "term-err");
+        } else if (roll < 0.12) {
+          line("PING " + host + ": 64 bytes, time=" + (300 + Math.floor(Math.random() * 500)) + "ms. someone's on hotel wifi.", "term-err");
+        } else if (roll < 0.17) {
+          line("PING " + host + ": 64 bytes, time=0.02ms. suspiciously close.", "term-dim");
+        } else {
+          var ms = 8 + Math.floor(Math.random() * 31);
+          line("PING " + host + ": 64 bytes, time=" + ms + "ms. it's alive.", "term-dim");
+        }
       },
     },
     make: {
@@ -269,28 +279,46 @@
     });
     at(2200, function () {
       var panic = document.querySelector("#meltdown-blackout .meltdown-panic");
-      if (panic) {
-        panic.classList.add("recovery");
-        panic.innerHTML = "tbd.codes recovery mode v0.1<br>";
-        var boots = ["fsck /dev/blog… clean", "fsck /dev/travel… clean", "restoring from backup… ok", "reticulating splines… ok"];
-        boots.forEach(function (b, i) {
-          setTimeout(function () { panic.innerHTML += b + "<br>"; }, 450 * (i + 1));
-        });
-      }
-    });
-    at(2600, function () {
-      var blackout = document.getElementById("meltdown-blackout");
-      if (blackout) {
-        blackout.classList.remove("on");
-        setTimeout(function () { blackout.remove(); }, 700);
-      }
-      document.body.classList.remove("melting");
-      if (!hadCrt) document.body.classList.remove("crt");
-    });
-    at(900, function () {
-      line("everything is fine. nothing was lost.", "term-dim");
-      line("(that was attempt #" + meltdownCount() + ". the site remembers.)", "term-dim");
-      melting = false;
+      if (!panic) return;
+      panic.classList.add("recovery");
+      panic.innerHTML = "tbd.codes recovery mode v0.1<br>";
+      var boots = ["fsck /dev/blog… clean", "fsck /dev/travel… clean", "restoring from backup… ok", "reticulating splines… ok"];
+      boots.forEach(function (b, i) {
+        setTimeout(function () { panic.innerHTML += b + "<br>"; }, 600 * (i + 1));
+      });
+      // Bootloader hold: wait for the visitor, however long that takes
+      setTimeout(function () {
+        panic.innerHTML += "<br><span class='meltdown-continue'>press enter to continue<span class='meltdown-blink'>_</span></span>";
+        var done = false;
+        function finish() {
+          if (done) return;
+          done = true;
+          document.removeEventListener("keydown", onKey);
+          var blackout = document.getElementById("meltdown-blackout");
+          if (blackout) {
+            blackout.removeEventListener("click", finish);
+            blackout.classList.remove("on");
+            setTimeout(function () { blackout.remove(); }, 700);
+          }
+          document.body.classList.remove("melting");
+          if (!hadCrt) document.body.classList.remove("crt");
+          setTimeout(function () {
+            line("everything is fine. nothing was lost.", "term-dim");
+            line("(that was attempt #" + meltdownCount() + ". the site remembers.)", "term-dim");
+            melting = false;
+            term.focus();
+          }, 500);
+        }
+        function onKey(e) {
+          if (e.key === "Enter" || e.key === " " || e.key === "Escape") {
+            e.preventDefault();
+            finish();
+          }
+        }
+        document.addEventListener("keydown", onKey);
+        var blackout = document.getElementById("meltdown-blackout");
+        if (blackout) blackout.addEventListener("click", finish);
+      }, 600 * 5);
     });
 
     var t = 0;


### PR DESCRIPTION
- The recovery screen now ends on a blinking `press enter to continue_` and **waits indefinitely** — enter/space/esc or a tap (mobile) resumes. Verified: held through a 4s idle probe, resumed cleanly on Enter.
- `ping` rolls weighted dice: 8–38ms normally, ~5% "someone's on hotel wifi" (300–800ms), ~7% "request timed out. probably fine.", ~5% "time=0.02ms. suspiciously close."

Suite: 19 passed (reduced-motion meltdown path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh