### PR TITLE
Stats page rescue: phosphor charts, palette wiring, snapshot history

### DIFF
--- a/cloudflare/view-counter-worker.js
+++ b/cloudflare/view-counter-worker.js
@@ -4,9 +4,15 @@
 //   /{key}      → { key, count }   (read only)
 //   /{key}/up   → { key, count }   (increment then read)
 //   /all        → { key: count, ... }  (requires Authorization: Bearer {STATS_SECRET})
+//   /history    → { "YYYY-MM-DD": total, ... }  (requires the same Bearer)
+//
+// A daily cron snapshots the total into __history:<date> keys so the stats
+// dashboard can chart reads over time (KV stores lifetime counters only).
 //
 // Requires a KV namespace bound as COUNTS (see wrangler.toml or dashboard setup).
 // Set the stats passphrase via: wrangler secret put STATS_SECRET
+
+const HISTORY_PREFIX = "__history:";
 
 export default {
   async fetch(request, env) {
@@ -27,19 +33,28 @@ export default {
       return json({ error: "missing key" }, 400, cors);
     }
 
-    if (key === "all") {
+    if (key === "all" || key === "history") {
       const auth = request.headers.get("Authorization");
       if (!env.STATS_SECRET || auth !== `Bearer ${env.STATS_SECRET}`) {
         return json({ error: "unauthorized" }, 401, cors);
       }
       const allKeys = await listAllKeys(env.COUNTS);
+      const wantHistory = key === "history";
+      const selected = allKeys.filter(({ name }) =>
+        wantHistory ? name.startsWith(HISTORY_PREFIX) : !name.startsWith(HISTORY_PREFIX)
+      );
       const entries = await Promise.all(
-        allKeys.map(async ({ name }) => {
+        selected.map(async ({ name }) => {
           const val = await env.COUNTS.get(name);
-          return [name, parseInt(val ?? "0", 10)];
+          const outName = wantHistory ? name.slice(HISTORY_PREFIX.length) : name;
+          return [outName, parseInt(val ?? "0", 10)];
         })
       );
       return json(Object.fromEntries(entries), 200, cors);
+    }
+
+    if (key.startsWith("__")) {
+      return json({ error: "reserved key" }, 400, cors);
     }
 
     const increment = parts[1] === "up";
@@ -52,6 +67,19 @@ export default {
     }
 
     return json({ key, count }, 200, cors);
+  },
+
+  // Daily snapshot: total reads → __history:<YYYY-MM-DD>
+  async scheduled(event, env) {
+    const allKeys = await listAllKeys(env.COUNTS);
+    const countKeys = allKeys.filter(({ name }) => !name.startsWith(HISTORY_PREFIX));
+    let total = 0;
+    for (const { name } of countKeys) {
+      const val = await env.COUNTS.get(name);
+      total += parseInt(val ?? "0", 10);
+    }
+    const date = new Date(event.scheduledTime).toISOString().slice(0, 10);
+    await env.COUNTS.put(HISTORY_PREFIX + date, String(total));
   },
 };
 

--- a/cloudflare/view-counter-wrangler.toml
+++ b/cloudflare/view-counter-wrangler.toml
@@ -2,6 +2,10 @@ name = "tbd-view-counter"
 main = "view-counter-worker.js"
 compatibility_date = "2025-01-01"
 
+# Daily snapshot of total reads for the stats dashboard's over-time chart
+[triggers]
+crons = ["0 4 * * *"]
+
 [[kv_namespaces]]
 binding = "COUNTS"
 id = "tbd-blog-view-counts"

--- a/css/stats.css
+++ b/css/stats.css
@@ -1,0 +1,299 @@
+/* Stats dashboard (password-gated) */
+
+#auth-screen {
+  padding: 2em 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6em;
+}
+
+/* The ID rule above outweighs .hidden's class specificity — restate it */
+#auth-screen.hidden {
+  display: none;
+}
+
+.auth-line {
+  font-family: "Fira Code", monospace;
+  font-size: 0.95em;
+  color: var(--fg);
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+.auth-line .prompt {
+  color: var(--accent);
+}
+
+#token-input {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--accent);
+  color: var(--accent);
+  font-family: "Fira Code", monospace;
+  font-size: 0.95em;
+  width: 18em;
+  outline: none;
+  padding: 0.1em 0.2em;
+}
+
+#auth-error {
+  font-family: "Fira Code", monospace;
+  font-size: 0.85em;
+  color: var(--err);
+  padding-left: 1.2em;
+}
+
+/* ── Dashboard ─────────────────────────────────────── */
+
+#dashboard {
+  padding: 0.5em 0 2em;
+}
+
+.stats-summary {
+  font-family: "Fira Code", monospace;
+  font-size: 0.88em;
+  color: var(--fg-dim);
+  margin-bottom: 1.4em;
+  line-height: 2;
+  border-left: 2px solid var(--accent-40);
+  padding-left: 1em;
+}
+
+.stats-summary .hl {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+/* ── Charts ────────────────────────────────────────── */
+
+.stats-charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
+  gap: 1em;
+  margin-bottom: 1.8em;
+}
+
+.chart-card {
+  background: var(--ph-1);
+  border: 1px solid var(--accent-08);
+  border-radius: 6px;
+  box-shadow: var(--bezel);
+  padding: 0.8em 1em 1em;
+  min-width: 0;
+}
+
+.chart-title {
+  font-family: "Fira Code", monospace;
+  font-size: 0.8em;
+  color: var(--fg-dim);
+  margin: 0 0 0.7em;
+}
+
+.hbar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6em;
+  padding: 2px 0; /* 2px surface gap between adjacent bars */
+  font-family: "Fira Code", monospace;
+  font-size: 0.78em;
+}
+
+.hbar-label {
+  color: var(--fg-dim);
+  width: 7.5em;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+}
+
+.hbar-track {
+  flex: 1;
+  min-width: 0;
+}
+
+.hbar-fill {
+  height: 8px;
+  /* validated mark color: accent @ .55 over ph-1 ≈ #24910f (passes
+     lightness band + contrast; full accent is reserved for thin marks) */
+  background: rgba(57, 255, 20, 0.55);
+  border-radius: 0 2px 2px 0; /* rounded data-end, flat baseline edge */
+  min-width: 1px;
+  transition: background 0.12s;
+}
+
+.hbar-row:hover .hbar-fill {
+  background: rgba(57, 255, 20, 0.8);
+}
+
+.hbar-value {
+  color: var(--fg);
+  width: 3.8em;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.chart-empty {
+  font-family: "Fira Code", monospace;
+  font-size: 0.78em;
+  color: var(--fg-dim);
+  padding: 0.5em 0;
+}
+
+/* Reads-over-time line */
+.spark-svg {
+  width: 100%;
+  height: 90px;
+  display: block;
+}
+
+.spark-svg .spark-line {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 2;
+}
+
+.spark-svg .spark-fill {
+  fill: rgba(57, 255, 20, 0.12);
+  stroke: none;
+}
+
+.spark-svg .spark-dot {
+  fill: var(--accent);
+}
+
+.spark-caption {
+  font-family: "Fira Code", monospace;
+  font-size: 0.72em;
+  color: var(--fg-dim);
+  display: flex;
+  justify-content: space-between;
+  margin-top: 0.3em;
+}
+
+/* ── Table ─────────────────────────────────────────── */
+
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: "Fira Code", monospace;
+  font-size: 0.83em;
+}
+
+.stats-table thead th {
+  text-align: left;
+  padding: 0.4em 0.7em;
+  border-bottom: 1px solid var(--accent-40);
+  color: var(--accent);
+  white-space: nowrap;
+  user-select: none;
+}
+
+.stats-table thead th[data-sort] {
+  cursor: pointer;
+}
+
+.stats-table thead th[data-sort]:hover,
+.stats-table thead th.sorted {
+  color: #fff;
+}
+
+.stats-table tbody tr:hover td {
+  background: rgba(57, 255, 20, 0.03);
+}
+
+.stats-table td {
+  padding: 0.32em 0.7em;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.035);
+  vertical-align: middle;
+  color: var(--fg);
+}
+
+.td-rank {
+  color: var(--fg-dim);
+  text-align: right;
+  width: 2.2em;
+  padding-right: 0.4em;
+}
+
+.td-title {
+  max-width: 28em;
+}
+
+.td-title a {
+  color: var(--fg);
+  text-decoration: none;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.td-title a:hover {
+  color: var(--accent);
+}
+
+.td-date {
+  color: var(--fg-dim);
+  white-space: nowrap;
+  width: 7em;
+  font-size: 0.9em;
+}
+
+.td-views {
+  text-align: right;
+  width: 4.5em;
+  white-space: nowrap;
+}
+
+.td-views.zero {
+  color: var(--fg-dim);
+}
+
+.td-bar {
+  width: 7em;
+  padding: 0 0.6em;
+}
+
+.bar-track {
+  height: 5px;
+  background: rgba(57, 255, 20, 0.07);
+  border-radius: 3px;
+}
+
+.bar-fill {
+  height: 5px;
+  background: rgba(57, 255, 20, 0.55);
+  border-radius: 3px;
+  min-width: 1px;
+}
+
+.td-reactions {
+  white-space: nowrap;
+  font-size: 0.88em;
+  color: var(--fg-dim);
+}
+
+.r-chip {
+  display: inline-block;
+  margin-right: 0.4em;
+}
+
+.r-chip .r-count {
+  font-size: 0.85em;
+  color: var(--fg-dim);
+  margin-left: 0.1em;
+}
+
+.sort-arrow {
+  font-size: 0.7em;
+  opacity: 0.6;
+  margin-left: 0.2em;
+}
+
+.th-bar,
+.th-rank {
+  width: 1px;
+}

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,0 +1,312 @@
+// Private stats dashboard: auth against the workers' STATS_SECRET, then
+// summary + charts + sortable per-post table. Charts are single-series
+// magnitude bars (validated dimmed-phosphor fills; full accent only on
+// thin marks). The table doubles as the accessible data view.
+(function () {
+  const COUNTER_BASE = "https://tbd-blog-view-counter.tomerno6.workers.dev";
+  const REACTIONS_BASE = "https://tbd-blog-post-reactions.tomerno6.workers.dev";
+
+  function postKey(filename) {
+    return filename.split("/").pop().replace(/\.[^.]+$/, "");
+  }
+
+  // ── Auth ────────────────────────────────────────────
+
+  const authScreen = document.getElementById("auth-screen");
+  const authError = document.getElementById("auth-error");
+  const tokenInput = document.getElementById("token-input");
+  const dashboard = document.getElementById("dashboard");
+
+  function showAuth(errorMsg) {
+    dashboard.classList.add("hidden");
+    authScreen.classList.remove("hidden");
+    if (errorMsg) {
+      authError.textContent = "> " + errorMsg;
+      authError.classList.remove("hidden");
+    } else {
+      authError.classList.add("hidden");
+    }
+    tokenInput.value = "";
+    tokenInput.focus();
+  }
+
+  tokenInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      const token = tokenInput.value.trim();
+      if (token) loadDashboard(token);
+    }
+  });
+
+  // ── Data loading ─────────────────────────────────────
+
+  let allPosts = [];
+  let history = null;
+  let currentSort = { key: "views", dir: -1 };
+
+  async function loadDashboard(token) {
+    authError.textContent = "> authenticating...";
+    authError.classList.remove("hidden");
+    tokenInput.disabled = true;
+
+    const headers = { Authorization: `Bearer ${token}` };
+
+    try {
+      const [index, views, reactions, hist] = await Promise.all([
+        fetch("posts/index.json").then((r) => r.json()),
+        fetch(`${COUNTER_BASE}/all`, { headers }).then((r) => {
+          if (r.status === 401) throw new Error("access denied");
+          if (!r.ok) throw new Error(`view counter: ${r.status}`);
+          return r.json();
+        }),
+        fetch(`${REACTIONS_BASE}/reactions/all`, { headers }).then((r) => {
+          if (r.status === 401) throw new Error("access denied");
+          if (!r.ok) throw new Error(`reactions: ${r.status}`);
+          return r.json();
+        }),
+        // Daily snapshots — absent until the redeployed worker's cron runs
+        fetch(`${COUNTER_BASE}/history`, { headers })
+          .then((r) => (r.ok ? r.json() : null))
+          .catch(() => null),
+      ]);
+
+      sessionStorage.setItem("stats_token", token);
+      tokenInput.disabled = false;
+
+      history = hist;
+      allPosts = index.map((post) => {
+        const key = postKey(post.filename);
+        const postViews = views[key] || 0;
+        const postReactions = reactions[key] || {};
+        const totalReactions = Object.values(postReactions).reduce((s, v) => s + v, 0);
+        return { ...post, key, views: postViews, reactions: postReactions, totalReactions };
+      });
+
+      authScreen.classList.add("hidden");
+      dashboard.classList.remove("hidden");
+      renderSummary();
+      renderCharts();
+      renderTable();
+      setupSortHeaders();
+    } catch (e) {
+      tokenInput.disabled = false;
+      showAuth(e.message);
+    }
+  }
+
+  // ── Summary ──────────────────────────────────────────
+
+  function renderSummary() {
+    const totalViews = allPosts.reduce((s, p) => s + p.views, 0);
+    const viewedPosts = allPosts.filter((p) => p.views > 0).length;
+    const totalReactions = allPosts.reduce((s, p) => s + p.totalReactions, 0);
+    const reactedPosts = allPosts.filter((p) => p.totalReactions > 0).length;
+
+    const summary = document.getElementById("summary");
+    summary.innerHTML =
+      `<span class="hl">${totalViews.toLocaleString()}</span> total reads across ` +
+      `<span class="hl">${viewedPosts}</span> of <span class="hl">${allPosts.length}</span> posts<br>` +
+      `<span class="hl">${totalReactions.toLocaleString()}</span> reactions on ` +
+      `<span class="hl">${reactedPosts}</span> posts`;
+  }
+
+  // ── Charts ───────────────────────────────────────────
+
+  function hbarChart(el, rows, formatValue) {
+    el.innerHTML = "";
+    if (!rows.length) {
+      el.innerHTML = "<p class='chart-empty'>no data yet.</p>";
+      return;
+    }
+    const max = Math.max(...rows.map((r) => r.value), 1);
+    rows.forEach((r) => {
+      const row = document.createElement("div");
+      row.className = "hbar-row";
+      row.title = `${r.label}: ${r.value.toLocaleString()}`;
+      const label = document.createElement("span");
+      label.className = "hbar-label";
+      label.textContent = r.label;
+      const track = document.createElement("div");
+      track.className = "hbar-track";
+      const fill = document.createElement("div");
+      fill.className = "hbar-fill";
+      fill.style.width = Math.max(1, Math.round((r.value / max) * 100)) + "%";
+      track.appendChild(fill);
+      const value = document.createElement("span");
+      value.className = "hbar-value";
+      value.textContent = formatValue ? formatValue(r.value) : r.value.toLocaleString();
+      row.appendChild(label);
+      row.appendChild(track);
+      row.appendChild(value);
+      el.appendChild(row);
+    });
+  }
+
+  function renderCharts() {
+    // Reads by category (top 8, rest folded into "other")
+    const byCat = {};
+    allPosts.forEach((p) => {
+      (p.categories || []).forEach((c) => {
+        const cat = String(c).toLowerCase();
+        if (cat === "travel") return; // umbrella tag on every travel post — noise
+        byCat[cat] = (byCat[cat] || 0) + p.views;
+      });
+    });
+    let cats = Object.entries(byCat).sort((a, b) => b[1] - a[1]);
+    const top = cats.slice(0, 8);
+    const rest = cats.slice(8).reduce((s, [, v]) => s + v, 0);
+    if (rest > 0) top.push(["other", rest]);
+    hbarChart(
+      document.getElementById("chart-categories"),
+      top.map(([label, value]) => ({ label, value }))
+    );
+
+    // Reads by post month (chronological)
+    const byMonth = {};
+    allPosts.forEach((p) => {
+      const m = (p.date || "").slice(0, 7);
+      if (!m) return;
+      byMonth[m] = (byMonth[m] || 0) + p.views;
+    });
+    const months = Object.entries(byMonth).sort((a, b) => (a[0] < b[0] ? -1 : 1));
+    hbarChart(
+      document.getElementById("chart-months"),
+      months.map(([label, value]) => ({ label, value }))
+    );
+
+    // Reactions by emoji
+    const emojiTotals = {};
+    allPosts.forEach((p) => {
+      Object.entries(p.reactions).forEach(([em, c]) => {
+        emojiTotals[em] = (emojiTotals[em] || 0) + c;
+      });
+    });
+    const emojis = Object.entries(emojiTotals).sort((a, b) => b[1] - a[1]).slice(0, 8);
+    hbarChart(
+      document.getElementById("chart-emoji"),
+      emojis.map(([label, value]) => ({ label, value }))
+    );
+
+    renderHistory();
+  }
+
+  function renderHistory() {
+    const el = document.getElementById("chart-history");
+    el.innerHTML = "";
+    const points = history
+      ? Object.entries(history).sort((a, b) => (a[0] < b[0] ? -1 : 1))
+      : [];
+    if (points.length < 2) {
+      el.innerHTML =
+        "<p class='chart-empty'>collecting daily snapshots — the chart appears once the redeployed worker has a few days of data.</p>";
+      return;
+    }
+    const w = 300, h = 90, pad = 6;
+    const vals = points.map((p) => p[1]);
+    const min = Math.min(...vals);
+    const max = Math.max(...vals);
+    const span = Math.max(max - min, 1);
+    const x = (i) => pad + (i / (points.length - 1)) * (w - 2 * pad);
+    const y = (v) => h - pad - ((v - min) / span) * (h - 2 * pad);
+    const coords = points.map((p, i) => `${x(i).toFixed(1)},${y(p[1]).toFixed(1)}`);
+    const last = points[points.length - 1];
+    const svg =
+      `<svg class="spark-svg" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" role="img" ` +
+      `aria-label="total reads, ${points[0][0]} to ${last[0]}">` +
+      `<polygon class="spark-fill" points="${pad},${h - pad} ${coords.join(" ")} ${w - pad},${h - pad}"/>` +
+      `<polyline class="spark-line" points="${coords.join(" ")}"/>` +
+      `<circle class="spark-dot" r="3" cx="${x(points.length - 1).toFixed(1)}" cy="${y(last[1]).toFixed(1)}"/>` +
+      `</svg>`;
+    el.innerHTML =
+      svg +
+      `<div class="spark-caption"><span>${points[0][0]}</span>` +
+      `<span>${last[0]} · ${last[1].toLocaleString()} reads</span></div>`;
+  }
+
+  // ── Table ────────────────────────────────────────────
+
+  function sortedPosts() {
+    const { key, dir } = currentSort;
+    return [...allPosts].sort((a, b) => {
+      let av, bv;
+      if (key === "views") { av = a.views; bv = b.views; }
+      else if (key === "reactions") { av = a.totalReactions; bv = b.totalReactions; }
+      else if (key === "date") { av = a.date || ""; bv = b.date || ""; }
+      else { av = (a.title || "").toLowerCase(); bv = (b.title || "").toLowerCase(); }
+      // dir -1 = descending (the ▼ default shows most-read first)
+      if (av < bv) return -dir;
+      if (av > bv) return dir;
+      return 0;
+    });
+  }
+
+  function renderTable() {
+    const posts = sortedPosts();
+    const maxViews = Math.max(...posts.map((p) => p.views), 1);
+    const tbody = document.getElementById("stats-tbody");
+    tbody.innerHTML = "";
+
+    posts.forEach((post, i) => {
+      const tr = document.createElement("tr");
+      const dateStr = (post.date || "").slice(0, 10);
+      const pct = Math.round((post.views / maxViews) * 100);
+      const url = `blog.html?post=${encodeURIComponent(post.filename)}`;
+
+      const reactionHtml = Object.entries(post.reactions)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 4)
+        .map(([em, c]) => `<span class="r-chip">${em}<span class="r-count">${c}</span></span>`)
+        .join("");
+
+      const titleEl = document.createElement("td");
+      titleEl.className = "td-title";
+      const a = document.createElement("a");
+      a.href = url;
+      a.textContent = post.title || post.filename;
+      a.title = post.title || post.filename;
+      titleEl.appendChild(a);
+
+      tr.innerHTML = `
+        <td class="td-rank">${i + 1}</td>
+        <td class="td-date">${dateStr}</td>
+        <td class="td-views${post.views === 0 ? " zero" : ""}">${post.views > 0 ? post.views.toLocaleString() : "—"}</td>
+        <td class="td-bar"><div class="bar-track"><div class="bar-fill" style="width:${pct}%"></div></div></td>
+        <td class="td-reactions">${reactionHtml || '<span style="opacity:0.3">—</span>'}</td>`;
+
+      tr.insertBefore(titleEl, tr.children[1]);
+      tbody.appendChild(tr);
+    });
+  }
+
+  function setupSortHeaders() {
+    document.querySelectorAll(".stats-table thead th[data-sort]").forEach((th) => {
+      th.addEventListener("click", () => {
+        const key = th.dataset.sort;
+        if (currentSort.key === key) {
+          currentSort.dir *= -1;
+        } else {
+          currentSort = { key, dir: -1 };
+        }
+        updateSortArrows();
+        renderTable();
+      });
+    });
+  }
+
+  function updateSortArrows() {
+    document.querySelectorAll(".stats-table thead th[data-sort]").forEach((th) => {
+      const arrow = th.querySelector(".sort-arrow");
+      const isActive = th.dataset.sort === currentSort.key;
+      th.classList.toggle("sorted", isActive);
+      arrow.textContent = isActive ? (currentSort.dir === -1 ? "▼" : "▲") : "";
+    });
+  }
+
+  // ── Init ─────────────────────────────────────────────
+
+  const saved = sessionStorage.getItem("stats_token");
+  if (saved) {
+    loadDashboard(saved);
+  } else {
+    tokenInput.focus();
+  }
+})();

--- a/stats.html
+++ b/stats.html
@@ -9,200 +9,10 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="css/terminal.css" />
+    <link rel="stylesheet" href="css/stats.css" />
     <link rel="icon" type="image/png" href="favicon.ico" />
     <link rel="alternate" type="application/rss+xml" title="tbd RSS Feed" href="/feed.xml" />
-    <style>
-      #auth-screen {
-        padding: 2em 0;
-        display: flex;
-        flex-direction: column;
-        gap: 0.6em;
-      }
-
-      .auth-line {
-        font-family: "Fira Code", monospace;
-        font-size: 0.95em;
-        color: var(--fg, #c8c8c8);
-        display: flex;
-        align-items: center;
-        gap: 0.5em;
-      }
-
-      .auth-line .prompt {
-        color: var(--accent, #39ff14);
-      }
-
-      #token-input {
-        background: transparent;
-        border: none;
-        border-bottom: 1px solid var(--accent, #39ff14);
-        color: var(--accent, #39ff14);
-        font-family: "Fira Code", monospace;
-        font-size: 0.95em;
-        width: 18em;
-        outline: none;
-        caret-color: var(--accent, #39ff14);
-        padding: 0.1em 0.2em;
-      }
-
-      #auth-error {
-        font-family: "Fira Code", monospace;
-        font-size: 0.85em;
-        color: #ff5555;
-        padding-left: 1.2em;
-      }
-
-      /* ── Dashboard ─────────────────────────────────────── */
-
-      #dashboard {
-        padding: 0.5em 0 2em;
-      }
-
-      .stats-summary {
-        font-family: "Fira Code", monospace;
-        font-size: 0.88em;
-        color: var(--fg-dim, #888);
-        margin-bottom: 1.8em;
-        line-height: 2;
-        border-left: 2px solid var(--accent-40, rgba(57, 255, 20, 0.25));
-        padding-left: 1em;
-      }
-
-      .stats-summary .hl {
-        color: var(--accent, #39ff14);
-        font-weight: 700;
-      }
-
-      /* ── Table ─────────────────────────────────────────── */
-
-      .stats-table {
-        width: 100%;
-        border-collapse: collapse;
-        font-family: "Fira Code", monospace;
-        font-size: 0.83em;
-      }
-
-      .stats-table thead th {
-        text-align: left;
-        padding: 0.4em 0.7em;
-        border-bottom: 1px solid var(--accent-40, rgba(57, 255, 20, 0.3));
-        color: var(--accent, #39ff14);
-        white-space: nowrap;
-        user-select: none;
-      }
-
-      .stats-table thead th[data-sort] {
-        cursor: pointer;
-      }
-
-      .stats-table thead th[data-sort]:hover {
-        color: #fff;
-      }
-
-      .stats-table thead th.sorted {
-        color: #fff;
-      }
-
-      .stats-table tbody tr:hover td {
-        background: rgba(57, 255, 20, 0.03);
-      }
-
-      .stats-table td {
-        padding: 0.32em 0.7em;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.035);
-        vertical-align: middle;
-        color: var(--fg, #c8c8c8);
-      }
-
-      .td-rank {
-        color: var(--fg-dim, #555);
-        text-align: right;
-        width: 2.2em;
-        padding-right: 0.4em;
-      }
-
-      .td-title {
-        max-width: 28em;
-      }
-
-      .td-title a {
-        color: var(--fg, #c8c8c8);
-        text-decoration: none;
-        display: block;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      .td-title a:hover {
-        color: var(--accent, #39ff14);
-      }
-
-      .td-date {
-        color: var(--fg-dim, #666);
-        white-space: nowrap;
-        width: 7em;
-        font-size: 0.9em;
-      }
-
-      .td-views {
-        text-align: right;
-        width: 4.5em;
-        color: #aaa;
-        white-space: nowrap;
-      }
-
-      .td-views.zero {
-        color: var(--fg-dim, #444);
-      }
-
-      .td-bar {
-        width: 7em;
-        padding: 0 0.6em;
-      }
-
-      .bar-track {
-        height: 5px;
-        background: rgba(57, 255, 20, 0.07);
-        border-radius: 3px;
-      }
-
-      .bar-fill {
-        height: 5px;
-        background: var(--accent, #39ff14);
-        border-radius: 3px;
-        opacity: 0.55;
-        min-width: 1px;
-      }
-
-      .td-reactions {
-        white-space: nowrap;
-        font-size: 0.88em;
-        color: var(--fg-dim, #777);
-      }
-
-      .r-chip {
-        display: inline-block;
-        margin-right: 0.4em;
-      }
-
-      .r-chip .r-count {
-        font-size: 0.85em;
-        color: var(--fg-dim, #666);
-        margin-left: 0.1em;
-      }
-
-      .sort-arrow {
-        font-size: 0.7em;
-        opacity: 0.6;
-        margin-left: 0.2em;
-      }
-
-      .th-bar,
-      .th-rank {
-        width: 1px;
-      }
-    </style>
   </head>
   <body>
     <header></header>
@@ -230,6 +40,26 @@
 
         <div id="dashboard" class="hidden">
           <div class="stats-summary" id="summary"></div>
+
+          <div class="stats-charts">
+            <div class="chart-card">
+              <p class="chart-title">$ reads --by-category</p>
+              <div id="chart-categories"></div>
+            </div>
+            <div class="chart-card">
+              <p class="chart-title">$ reads --by-post-month</p>
+              <div id="chart-months"></div>
+            </div>
+            <div class="chart-card">
+              <p class="chart-title">$ reactions --by-emoji</p>
+              <div id="chart-emoji"></div>
+            </div>
+            <div class="chart-card">
+              <p class="chart-title">$ reads --over-time</p>
+              <div id="chart-history"></div>
+            </div>
+          </div>
+
           <table class="stats-table" id="stats-table">
             <thead>
               <tr>
@@ -255,210 +85,10 @@
     <footer></footer>
     <script src="js/main.js"></script>
     <script src="js/include-components.js"></script>
-    <script>
-      const COUNTER_BASE =
-        "https://tbd-blog-view-counter.tomerno6.workers.dev";
-      const REACTIONS_BASE =
-        "https://tbd-blog-post-reactions.tomerno6.workers.dev";
-
-      function postKey(filename) {
-        return filename.split("/").pop().replace(/\.[^.]+$/, "");
-      }
-
-      // ── Auth ────────────────────────────────────────────
-
-      const authScreen = document.getElementById("auth-screen");
-      const authError = document.getElementById("auth-error");
-      const tokenInput = document.getElementById("token-input");
-      const dashboard = document.getElementById("dashboard");
-
-      function showAuth(errorMsg) {
-        dashboard.classList.add("hidden");
-        authScreen.classList.remove("hidden");
-        if (errorMsg) {
-          authError.textContent = "> " + errorMsg;
-          authError.classList.remove("hidden");
-        } else {
-          authError.classList.add("hidden");
-        }
-        tokenInput.value = "";
-        tokenInput.focus();
-      }
-
-      tokenInput.addEventListener("keydown", (e) => {
-        if (e.key === "Enter") {
-          const token = tokenInput.value.trim();
-          if (token) loadDashboard(token);
-        }
-      });
-
-      // ── Data loading ─────────────────────────────────────
-
-      let allPosts = [];
-      let currentSort = { key: "views", dir: -1 };
-
-      async function loadDashboard(token) {
-        authError.textContent = "> authenticating...";
-        authError.classList.remove("hidden");
-        tokenInput.disabled = true;
-
-        const headers = { Authorization: `Bearer ${token}` };
-
-        try {
-          const [index, views, reactions] = await Promise.all([
-            fetch("posts/index.json").then((r) => r.json()),
-            fetch(`${COUNTER_BASE}/all`, { headers }).then((r) => {
-              if (r.status === 401) throw new Error("access denied");
-              if (!r.ok) throw new Error(`view counter: ${r.status}`);
-              return r.json();
-            }),
-            fetch(`${REACTIONS_BASE}/reactions/all`, { headers }).then((r) => {
-              if (r.status === 401) throw new Error("access denied");
-              if (!r.ok) throw new Error(`reactions: ${r.status}`);
-              return r.json();
-            }),
-          ]);
-
-          sessionStorage.setItem("stats_token", token);
-
-          allPosts = index.map((post) => {
-            const key = postKey(post.filename);
-            const postViews = views[key] || 0;
-            const postReactions = reactions[key] || {};
-            const totalReactions = Object.values(postReactions).reduce(
-              (s, v) => s + v,
-              0
-            );
-            return { ...post, key, views: postViews, reactions: postReactions, totalReactions };
-          });
-
-          authScreen.classList.add("hidden");
-          dashboard.classList.remove("hidden");
-          renderSummary();
-          renderTable();
-          setupSortHeaders();
-        } catch (e) {
-          tokenInput.disabled = false;
-          showAuth(e.message);
-        }
-      }
-
-      // ── Summary ──────────────────────────────────────────
-
-      function renderSummary() {
-        const totalViews = allPosts.reduce((s, p) => s + p.views, 0);
-        const viewedPosts = allPosts.filter((p) => p.views > 0).length;
-        const totalReactions = allPosts.reduce((s, p) => s + p.totalReactions, 0);
-        const reactedPosts = allPosts.filter((p) => p.totalReactions > 0).length;
-
-        // Top emoji across all posts
-        const emojiTotals = {};
-        allPosts.forEach((p) => {
-          Object.entries(p.reactions).forEach(([em, c]) => {
-            emojiTotals[em] = (emojiTotals[em] || 0) + c;
-          });
-        });
-        const topEmojis = Object.entries(emojiTotals)
-          .sort((a, b) => b[1] - a[1])
-          .slice(0, 5)
-          .map(([em, c]) => `${em} ${c}`)
-          .join("  ");
-
-        const summary = document.getElementById("summary");
-        summary.innerHTML =
-          `<span class="hl">${totalViews.toLocaleString()}</span> total reads across ` +
-          `<span class="hl">${viewedPosts}</span> of <span class="hl">${allPosts.length}</span> posts<br>` +
-          `<span class="hl">${totalReactions.toLocaleString()}</span> reactions on ` +
-          `<span class="hl">${reactedPosts}</span> posts` +
-          (topEmojis ? `<br>top reactions: ${topEmojis}` : "");
-      }
-
-      // ── Table ────────────────────────────────────────────
-
-      function sortedPosts() {
-        const { key, dir } = currentSort;
-        return [...allPosts].sort((a, b) => {
-          let av, bv;
-          if (key === "views") { av = a.views; bv = b.views; }
-          else if (key === "reactions") { av = a.totalReactions; bv = b.totalReactions; }
-          else if (key === "date") { av = a.date || ""; bv = b.date || ""; }
-          else { av = (a.title || "").toLowerCase(); bv = (b.title || "").toLowerCase(); }
-          if (av < bv) return dir;
-          if (av > bv) return -dir;
-          return 0;
-        });
-      }
-
-      function renderTable() {
-        const posts = sortedPosts();
-        const maxViews = Math.max(...posts.map((p) => p.views), 1);
-        const tbody = document.getElementById("stats-tbody");
-        tbody.innerHTML = "";
-
-        posts.forEach((post, i) => {
-          const tr = document.createElement("tr");
-          const dateStr = (post.date || "").slice(0, 10);
-          const pct = Math.round((post.views / maxViews) * 100);
-          const url = `blog.html?post=${encodeURIComponent(post.filename)}`;
-
-          const reactionHtml = Object.entries(post.reactions)
-            .sort((a, b) => b[1] - a[1])
-            .slice(0, 4)
-            .map(([em, c]) => `<span class="r-chip">${em}<span class="r-count">${c}</span></span>`)
-            .join("");
-
-          const titleEl = document.createElement("td");
-          titleEl.className = "td-title";
-          const a = document.createElement("a");
-          a.href = url;
-          a.textContent = post.title || post.filename;
-          a.title = post.title || post.filename;
-          titleEl.appendChild(a);
-
-          tr.innerHTML = `
-            <td class="td-rank">${i + 1}</td>
-            <td class="td-date">${dateStr}</td>
-            <td class="td-views${post.views === 0 ? " zero" : ""}">${post.views > 0 ? post.views.toLocaleString() : "—"}</td>
-            <td class="td-bar"><div class="bar-track"><div class="bar-fill" style="width:${pct}%"></div></div></td>
-            <td class="td-reactions">${reactionHtml || '<span style="opacity:0.3">—</span>'}</td>`;
-
-          tr.insertBefore(titleEl, tr.children[1]);
-          tbody.appendChild(tr);
-        });
-      }
-
-      function setupSortHeaders() {
-        document.querySelectorAll(".stats-table thead th[data-sort]").forEach((th) => {
-          th.addEventListener("click", () => {
-            const key = th.dataset.sort;
-            if (currentSort.key === key) {
-              currentSort.dir *= -1;
-            } else {
-              currentSort = { key, dir: -1 };
-            }
-            updateSortArrows();
-            renderTable();
-          });
-        });
-      }
-
-      function updateSortArrows() {
-        document.querySelectorAll(".stats-table thead th[data-sort]").forEach((th) => {
-          const arrow = th.querySelector(".sort-arrow");
-          const isActive = th.dataset.sort === currentSort.key;
-          th.classList.toggle("sorted", isActive);
-          arrow.textContent = isActive ? (currentSort.dir === -1 ? "▼" : "▲") : "";
-        });
-      }
-
-      // ── Init ─────────────────────────────────────────────
-
-      const saved = sessionStorage.getItem("stats_token");
-      if (saved) {
-        loadDashboard(saved);
-      } else {
-        tokenInput.focus();
-      }
-    </script>
+    <script src="js/term-core.js"></script>
+    <script src="js/term-commands.js"></script>
+    <script src="js/now-data.js"></script>
+    <script src="js/term-overlay.js"></script>
+    <script src="js/stats.js"></script>
   </body>
 </html>

--- a/tests/smoke/stats.spec.js
+++ b/tests/smoke/stats.spec.js
@@ -1,0 +1,68 @@
+const { test, expect } = require("@playwright/test");
+const { phosphorPage } = require("../helpers");
+
+const CORS = { "Access-Control-Allow-Origin": "*" };
+
+test("stats: auth gate, summary, charts, sortable table", async ({ page, request }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());
+
+  const index = await (await request.get("/posts/index.json")).json();
+  const k = (f) => f.split("/").pop().replace(/\.[^.]+$/, "");
+  const views = {};
+  views[k(index[0].filename)] = 40;
+  views[k(index[1].filename)] = 25;
+  const reactions = {};
+  reactions[k(index[0].filename)] = { "❤️": 3, "👍": 2 };
+
+  await page.route("https://tbd-blog-view-counter.tomerno6.workers.dev/all", (r) =>
+    r.fulfill({ json: views, headers: CORS })
+  );
+  await page.route("https://tbd-blog-view-counter.tomerno6.workers.dev/history", (r) =>
+    r.fulfill({ json: { "2026-07-01": 40, "2026-07-04": 52, "2026-07-07": 65 }, headers: CORS })
+  );
+  await page.route("https://tbd-blog-post-reactions.tomerno6.workers.dev/reactions/all", (r) =>
+    r.fulfill({ json: reactions, headers: CORS })
+  );
+
+  await page.goto("/stats.html", { waitUntil: "domcontentloaded" });
+  await expect(page.locator("#auth-screen")).toBeVisible();
+  await page.fill("#token-input", "letmein");
+  await page.press("#token-input", "Enter");
+
+  await expect(page.locator("#dashboard")).toBeVisible();
+  await expect(page.locator("#auth-screen")).toBeHidden(); // ID-specificity regression guard
+  await expect(page.locator("#summary")).toContainText("65 total reads");
+  // Charts render: categories, post-months, emoji bars + history line
+  await expect(page.locator("#chart-categories .hbar-row").first()).toBeVisible();
+  await expect(page.locator("#chart-months .hbar-row").first()).toBeVisible();
+  await expect(page.locator("#chart-emoji .hbar-row").first()).toBeVisible();
+  await expect(page.locator("#chart-history .spark-svg")).toBeVisible();
+  await expect(page.locator("#chart-history .spark-caption")).toContainText("65 reads");
+  // Table renders every post; top row is the most-viewed
+  await expect(page.locator("#stats-tbody tr")).toHaveCount(index.length);
+  await expect(page.locator("#stats-tbody tr").first()).toContainText("40");
+  // Palette button exists here too (page is fully wired now)
+  await expect(page.locator(".nav-term-btn")).toBeVisible();
+  expect(errors).toEqual([]);
+});
+
+test("stats: wrong passphrase is rejected; history absent degrades", async ({ page }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());
+  await page.route("https://tbd-blog-view-counter.tomerno6.workers.dev/all", (r) =>
+    r.fulfill({ status: 401, json: { error: "unauthorized" }, headers: CORS })
+  );
+  await page.route("https://tbd-blog-view-counter.tomerno6.workers.dev/history", (r) =>
+    r.fulfill({ status: 401, json: { error: "unauthorized" }, headers: CORS })
+  );
+  await page.route("https://tbd-blog-post-reactions.tomerno6.workers.dev/reactions/all", (r) =>
+    r.fulfill({ status: 401, json: { error: "unauthorized" }, headers: CORS })
+  );
+  await page.goto("/stats.html", { waitUntil: "domcontentloaded" });
+  await page.fill("#token-input", "wrong");
+  await page.press("#token-input", "Enter");
+  await expect(page.locator("#auth-error")).toContainText("access denied");
+  await expect(page.locator("#dashboard")).toBeHidden();
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
The last page untouched by the overhaul joins the system.

## What's new

- **Chart grid** above the table: `$ reads --by-category`, `--by-post-month`, `$ reactions --by-emoji` (single-series horizontal bars), and `$ reads --over-time` (SVG line + area). Bar fills use accent@55% ≈ `#24910f` — **validated** with the palette checker (raw `#39ff14` fails the lightness band for filled marks; full accent stays on thin marks only). The sortable table remains as the accessible data view.
- **History**: the view-counter worker gains a daily snapshot cron (`__history:<date>` keys, excluded from `/all`) + a Bearer-gated `/history` endpoint. The chart shows a "collecting" notice until the redeployed worker accumulates a few days.
- **Page wiring**: styles → `css/stats.css`, script → `js/stats.js`, terminal.css + palette scripts added — **the `>_` nav button was dead on this page** (term-overlay.js never loaded here; missed in #35).

## Two inherited bugs fixed

1. The views sort comparator was inverted — the ▼ default showed *least*-read posts first.
2. `#auth-screen`'s ID-selector `display:flex` outweighed `.hidden`, so the login prompt never disappeared after successful auth.

## Deploy note (bundles with the pending CORS redeploy)

`wrangler deploy -c cloudflare/view-counter-wrangler.toml` — picks up the cron trigger + /history.

Suite: 21 passed (2 new stats specs: full dashboard flow with mocked workers incl. specificity regression guard, and wrong-passphrase rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh