### PR TITLE
Map ↔ music cross-links: songs in popups, shelf × log overlap

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1488,3 +1488,7 @@ a:hover {
     animation: none;
   }
 }
+
+.vinyl-logged {
+  color: var(--amber);
+}

--- a/css/travel.css
+++ b/css/travel.css
@@ -218,3 +218,12 @@
   min-height: 1.2em;
   margin: 0.2em 0;
 }
+
+/* The day's song in marker popups */
+.travel-popup-song {
+  font-size: 0.85em;
+}
+
+.travel-popup-song a {
+  color: var(--amber, #ffb000);
+}

--- a/js/music-shelf.js
+++ b/js/music-shelf.js
@@ -4,15 +4,42 @@
   const shelfEl = document.getElementById("vinyl-shelf");
   if (!shelfEl) return;
 
-  fetch("data/discogs.json")
-    .then((r) => (r.ok ? r.json() : []))
-    .then((releases) => {
+  Promise.all([
+    fetch("data/discogs.json").then((r) => (r.ok ? r.json() : [])),
+    fetch("posts/index.json").then((r) => (r.ok ? r.json() : [])).catch(() => []),
+    fetch("data/songlog.json").then((r) => (r.ok ? r.json() : null)).catch(() => null),
+  ])
+    .then(([releases, posts, songlogData]) => {
       if (!Array.isArray(releases) || releases.length === 0) return;
+
+      // Shelf ∩ song log: count each shelf artist's appearances in the log
+      // (substring joins — works for Hebrew and Latin names alike)
+      const songs = posts
+        .filter((p) => p.song_of_the_day)
+        .map((p) => p.song_of_the_day.toLowerCase())
+        .concat(
+          (songlogData && Array.isArray(songlogData.tracks) ? songlogData.tracks : [])
+            .map((t) => (t.song || "").toLowerCase())
+        );
+      const loggedCount = (artist) => {
+        const names = (artist || "").split(", ").map((a) => a.trim().toLowerCase()).filter((a) => a.length > 2);
+        let n = 0;
+        songs.forEach((s) => {
+          if (names.some((name) => s.includes(name))) n++;
+        });
+        return n;
+      };
+      releases.forEach((r) => { r._logged = loggedCount(r.artist); });
+      const overlap = new Set(
+        releases.filter((r) => r._logged > 0).map((r) => r.artist)
+      ).size;
 
       shelfEl.classList.remove("hidden");
       const header = document.createElement("p");
       header.className = "song-log-header";
-      header.textContent = `$ ls ~/vinyl  # ${releases.length} records`;
+      header.textContent =
+        `$ ls ~/vinyl  # ${releases.length} records` +
+        (overlap > 0 ? ` · ${overlap} artists also in the song log` : "");
       shelfEl.appendChild(header);
 
       // Genre chips (top genres by count, max 8)
@@ -64,6 +91,13 @@
             mbdi.textContent = r.artist || "";
             meta.appendChild(mbdi);
             if (r.year) meta.appendChild(document.createTextNode(` · ${r.year}`));
+            if (r._logged > 0) {
+              const badge = document.createElement("span");
+              badge.className = "vinyl-logged";
+              badge.textContent = ` ♪×${r._logged}`;
+              badge.title = `in the song log ${r._logged} time${r._logged === 1 ? "" : "s"}`;
+              meta.appendChild(badge);
+            }
             card.appendChild(cover);
             card.appendChild(title);
             card.appendChild(meta);

--- a/js/travel.js
+++ b/js/travel.js
@@ -186,7 +186,8 @@
     fetch("posts/locations.json").then(function (r) { return r.ok ? r.json() : {}; }).catch(function () { return {}; }),
     fetch("posts/timeline.json").then(function (r) { return r.ok ? r.json() : []; }).catch(function () { return []; }),
     fetch("posts/geocoded.json").then(function (r) { return r.ok ? r.json() : {}; }).catch(function () { return {}; }),
-    fetch("data/trips.json").then(function (r) { return r.ok ? r.json() : []; }).catch(function () { return []; })
+    fetch("data/trips.json").then(function (r) { return r.ok ? r.json() : []; }).catch(function () { return []; }),
+    fetch("data/songlog.json").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; })
   ])
   .then(function (results) {
     var posts           = results[0] || [];
@@ -194,6 +195,33 @@
     var timelinePoints  = Array.isArray(results[2]) ? results[2] : [];
     var geocoded        = results[3] || {};
     var tripsConfig     = Array.isArray(results[4]) ? results[4] : [];
+    var songlogTracks   = results[5] && Array.isArray(results[5].tracks) ? results[5].tracks : [];
+
+    // The map and the song log describe the same days — join them.
+    var dateToSong = {};
+    posts.forEach(function (p) {
+      if (p.song_of_the_day) dateToSong[postDate(p)] = { text: p.song_of_the_day, url: null };
+    });
+    songlogTracks.forEach(function (t) {
+      if (t.date && t.song && !dateToSong[t.date]) dateToSong[t.date] = { text: t.song, url: t.url || null };
+    });
+
+    function postPopup(post, headerHtml) {
+      var d = postDate(post);
+      var song = dateToSong[d];
+      var songHtml = "";
+      if (song) {
+        var href = song.url || ("https://www.youtube.com/results?search_query=" + encodeURIComponent(song.text));
+        songHtml = "<span class='travel-popup-song'>♪ <a target='_blank' rel='noopener' href='" + href + "'><bdi>" + song.text + "</bdi></a></span><br>";
+      }
+      return "<div class='travel-popup'>" +
+        (headerHtml || "") +
+        "<strong>" + (post.title || post.filename) + "</strong><br>" +
+        "<span class='travel-popup-date'>" + d + "</span><br>" +
+        songHtml +
+        "<a href='blog?post=" + encodeURIComponent(post.filename) + "'>Read post &rarr;</a>" +
+        "</div>";
+    }
 
     // Build date -> [{lat, lng}] from timeline visits (all visits per day)
     var timelineByDate = {};
@@ -389,12 +417,7 @@
       var ptCountry = countryForDate(d);
       var marker = L.marker([pt.lat, pt.lng], { icon: makeDotIcon(getCountryColor(ptCountry)), zIndexOffset: -100 });
       if (post) {
-        var popup = "<div class='travel-popup'>" +
-          "<strong>" + (post.title || post.filename) + "</strong><br>" +
-          "<span class='travel-popup-date'>" + (post.date || "").split(" ")[0] + "</span><br>" +
-          "<a href='blog?post=" + encodeURIComponent(post.filename) + "'>Read post &rarr;</a>" +
-          "</div>";
-        marker.bindPopup(popup);
+        marker.bindPopup(postPopup(post));
       }
       owner.routeLayer.addLayer(marker);
     });
@@ -431,14 +454,10 @@
       trip.markerLayer = makeClusterGroup();
       trip.latLngs = [];
       trip.items.forEach(function (item) {
-        var post = item.post;
         trip.latLngs.push(item.coords);
-        var popup = "<div class='travel-popup'>" +
-          "<strong>" + (post.title || post.filename) + "</strong><br>" +
-          "<span class='travel-popup-date'>" + (post.date || "").split(" ")[0] + "</span><br>" +
-          "<a href='blog?post=" + encodeURIComponent(post.filename) + "'>Read post &rarr;</a>" +
-          "</div>";
-        trip.markerLayer.addLayer(L.marker(item.coords, { icon: postIcon }).bindPopup(popup));
+        trip.markerLayer.addLayer(
+          L.marker(item.coords, { icon: postIcon }).bindPopup(postPopup(item.post))
+        );
       });
     });
 
@@ -450,14 +469,8 @@
       iconSize: [16, 16],
       iconAnchor: [8, 8]
     });
-    var currentPopup = "<div class='travel-popup'>" +
-      "<strong style='font-size:0.9em;opacity:0.7;'>📍 last stop</strong><br>" +
-      "<strong>" + (latest.post.title || latest.post.filename) + "</strong><br>" +
-      "<span class='travel-popup-date'>" + (latest.post.date || "").split(" ")[0] + "</span><br>" +
-      "<a href='blog?post=" + encodeURIComponent(latest.post.filename) + "'>Read post &rarr;</a>" +
-      "</div>";
     L.marker(latest.coords, { icon: currentIcon, zIndexOffset: 1000 })
-      .bindPopup(currentPopup)
+      .bindPopup(postPopup(latest.post, "<strong style='font-size:0.9em;opacity:0.7;'>📍 last stop</strong><br>"))
       .addTo(map);
 
     // --- Trip selection ---

--- a/tests/smoke/music.spec.js
+++ b/tests/smoke/music.spec.js
@@ -60,6 +60,30 @@ test("playlist era extends the log with month separators", async ({ page, reques
   expect(errors).toEqual([]);
 });
 
+test("vinyl shelf badges artists that appear in the song log", async ({ page }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());
+  await page.route("**/data/discogs.json", (r) => r.fulfill({ json: MOCK_VINYL }));
+  await page.route("**/data/songlog.json", (r) =>
+    r.fulfill({
+      json: {
+        tracks: [
+          { date: "2026-07-01", song: "Pyramid Song - Radiohead", month: "2026-07" },
+          { date: "2026-07-02", song: "Weird Fishes - Radiohead", month: "2026-07" },
+        ],
+      },
+    })
+  );
+  await page.goto("/music.html", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector(".vinyl-card");
+  await expect(page.locator(".vinyl-shelf .song-log-header")).toContainText("1 artists also in the song log");
+  const radiohead = page.locator(".vinyl-card", { hasText: "In Rainbows" });
+  await expect(radiohead.locator(".vinyl-logged")).toHaveText(/♪×2/);
+  const miles = page.locator(".vinyl-card", { hasText: "Kind of Blue" });
+  await expect(miles.locator(".vinyl-logged")).toHaveCount(0);
+  expect(errors).toEqual([]);
+});
+
 test("vinyl shelf renders from data and hides without it", async ({ page }) => {
   const errors = await phosphorPage(page);
   await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());

--- a/tests/smoke/travel.spec.js
+++ b/tests/smoke/travel.spec.js
@@ -40,6 +40,34 @@ test("replay never loads tiles and stops cleanly", async ({ page }) => {
   expect(errors).toEqual([]);
 });
 
+test("marker popups carry the day's song", async ({ page }) => {
+  const errors = await phosphorPage(page);
+  await page.route("**/posts/index.json", async (route) => {
+    const res = await route.fetch();
+    const posts = await res.json();
+    posts.push({
+      filename: "Polarsteps/Israel/999_haifa.md",
+      title: "Day 999 - Haifa",
+      date: "2027-01-01 10:00",
+      categories: ["travel", "Israel"],
+      song_of_the_day: "Karma Police - Radiohead",
+    });
+    await route.fulfill({ response: res, json: posts });
+  });
+  await page.route("**/posts/locations.json", async (route) => {
+    const res = await route.fetch();
+    const loc = await res.json();
+    loc["Polarsteps/Israel/999_haifa.md"] = { lat: 32.79, lng: 34.98 };
+    await route.fulfill({ response: res, json: loc });
+  });
+  await page.goto("/travel.html", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector(".travel-marker-current", { timeout: 20000 });
+  await page.locator(".travel-marker-current").click();
+  await expect(page.locator(".leaflet-popup")).toContainText("Day 999 - Haifa");
+  await expect(page.locator(".leaflet-popup .travel-popup-song")).toContainText("Karma Police");
+  expect(errors).toEqual([]);
+});
+
 test("second trip gets chips and disconnected routes", async ({ page }) => {
   const errors = await phosphorPage(page);
   await page.route("**/posts/index.json", async (route) => {


### PR DESCRIPTION
The map and the song log describe the same days but never touched:

- **Every marker popup** (post markers, timeline dots, the last-stop pin — deduplicated into one popup builder) now shows the day's ♪ with a play link (Spotify URL for playlist-era tracks, YouTube search otherwise)
- **The vinyl shelf joins the log**: each shelf artist's appearances are counted via case-insensitive substring joins (works for עידן רייכל as well as Radiohead) — matching cards get an amber `♪×N` badge and the header gains `· K artists also in the song log`

Suite: 25 passed (popup-song via doctored latest post; badge + overlap-count with mocked shelf/log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh