### PR TITLE
Shared visitor memory: the wall, presence, global meltdown tally

### DIFF
--- a/404.html
+++ b/404.html
@@ -71,6 +71,7 @@
     <footer></footer>
     <script src="/js/include-components.js"></script>
     <script src="/js/site-data.js"></script>
+    <script src="/js/presence.js"></script>
     <script src="/js/term-core.js"></script>
     <script src="/js/term-commands.js"></script>
     <script src="/js/now-data.js"></script>

--- a/blog.html
+++ b/blog.html
@@ -69,6 +69,7 @@
     <script src="js/main.js"></script>
     <script src="js/include-components.js"></script>
     <script src="js/site-data.js"></script>
+    <script src="js/presence.js"></script>
     <script src="js/term-core.js"></script>
     <script src="js/term-commands.js"></script>
     <script src="js/now-data.js"></script>

--- a/cloudflare/visitors-worker.js
+++ b/cloudflare/visitors-worker.js
@@ -1,0 +1,143 @@
+// Cloudflare Worker — shared visitor memory for tbd.codes
+//
+// API:
+//   GET  /meltdown            → { attempts, vandals }
+//   POST /meltdown            → increment; body {first:true} also counts a new vandal
+//   GET  /presence            → { here }               (heartbeats seen in the last 5 min)
+//   POST /presence {id}       → heartbeat; returns { here }
+//   GET  /wall                → { messages: [{text, ts}, …] }  (latest 10, newest first)
+//   POST /wall {text}         → add a line (≤120 chars, 3/hour per IP)
+//   GET  /wall/all            → every message with keys (Bearer STATS_SECRET)
+//   POST /wall/delete {key}   → remove one (Bearer STATS_SECRET)
+//
+// Setup: create a KV namespace bound as VISITORS, `wrangler secret put
+// STATS_SECRET -c visitors-wrangler.toml` (same passphrase as the other
+// workers), then `wrangler deploy -c visitors-wrangler.toml`.
+
+const ALLOWED_ORIGINS = ["https://tbd.codes", "http://localhost:8080", "http://127.0.0.1:8080"];
+const WALL_MAX = 120;
+const WALL_KEEP = 50;
+const WALL_RATE = 3; // per hour per IP
+const PRESENCE_TTL = 300; // seconds
+
+export default {
+  async fetch(request, env) {
+    const origin = request.headers.get("Origin") || "";
+    const cors = {
+      "Access-Control-Allow-Origin": ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0],
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+      "Vary": "Origin",
+    };
+    if (request.method === "OPTIONS") return new Response(null, { status: 204, headers: cors });
+
+    const path = new URL(request.url).pathname.replace(/\/+$/, "");
+
+    try {
+      if (path === "/meltdown") return await meltdown(request, env, cors);
+      if (path === "/presence") return await presence(request, env, cors);
+      if (path === "/wall") return await wall(request, env, cors);
+      if (path === "/wall/all") return await wallAll(request, env, cors);
+      if (path === "/wall/delete") return await wallDelete(request, env, cors);
+    } catch (e) {
+      return json({ error: String(e).slice(0, 100) }, 500, cors);
+    }
+    return json({ error: "not found" }, 404, cors);
+  },
+};
+
+async function meltdown(request, env, cors) {
+  if (request.method === "POST") {
+    const body = await request.json().catch(() => ({}));
+    const attempts = parseInt((await env.VISITORS.get("meltdown:attempts")) ?? "0", 10) + 1;
+    await env.VISITORS.put("meltdown:attempts", String(attempts));
+    let vandals = parseInt((await env.VISITORS.get("meltdown:vandals")) ?? "0", 10);
+    if (body.first) {
+      vandals++;
+      await env.VISITORS.put("meltdown:vandals", String(vandals));
+    }
+    return json({ attempts, vandals }, 200, cors);
+  }
+  const attempts = parseInt((await env.VISITORS.get("meltdown:attempts")) ?? "0", 10);
+  const vandals = parseInt((await env.VISITORS.get("meltdown:vandals")) ?? "0", 10);
+  return json({ attempts, vandals }, 200, cors);
+}
+
+async function presence(request, env, cors) {
+  if (request.method === "POST") {
+    const body = await request.json().catch(() => ({}));
+    const id = String(body.id || "").replace(/[^a-z0-9-]/gi, "").slice(0, 40);
+    if (id) await env.VISITORS.put("p:" + id, "1", { expirationTtl: PRESENCE_TTL });
+  }
+  const list = await env.VISITORS.list({ prefix: "p:" });
+  return json({ here: list.keys.length }, 200, cors);
+}
+
+async function wall(request, env, cors) {
+  if (request.method === "POST") {
+    const ip = request.headers.get("CF-Connecting-IP") || "unknown";
+    const rlKey = "rl:" + ip;
+    const used = parseInt((await env.VISITORS.get(rlKey)) ?? "0", 10);
+    if (used >= WALL_RATE) return json({ error: "rate limited" }, 429, cors);
+
+    const body = await request.json().catch(() => ({}));
+    const text = String(body.text || "").replace(/\s+/g, " ").trim();
+    if (!text) return json({ error: "empty" }, 400, cors);
+    if (text.length > WALL_MAX) return json({ error: "too long" }, 400, cors);
+
+    const ts = Date.now();
+    await env.VISITORS.put(
+      "w:" + String(ts).padStart(15, "0") + ":" + Math.random().toString(36).slice(2, 8),
+      JSON.stringify({ text, ts })
+    );
+    await env.VISITORS.put(rlKey, String(used + 1), { expirationTtl: 3600 });
+
+    // Keep the wall finite: prune beyond the newest WALL_KEEP
+    const all = await env.VISITORS.list({ prefix: "w:" });
+    if (all.keys.length > WALL_KEEP) {
+      const excess = all.keys.slice(0, all.keys.length - WALL_KEEP); // list is key-ordered = oldest first
+      for (const k of excess) await env.VISITORS.delete(k.name);
+    }
+    return json({ ok: true }, 200, cors);
+  }
+
+  const list = await env.VISITORS.list({ prefix: "w:" });
+  const latest = list.keys.slice(-10).reverse();
+  const messages = [];
+  for (const k of latest) {
+    const val = await env.VISITORS.get(k.name);
+    if (val) messages.push(JSON.parse(val));
+  }
+  return json({ messages }, 200, cors);
+}
+
+function authed(request, env) {
+  const auth = request.headers.get("Authorization");
+  return env.STATS_SECRET && auth === `Bearer ${env.STATS_SECRET}`;
+}
+
+async function wallAll(request, env, cors) {
+  if (!authed(request, env)) return json({ error: "unauthorized" }, 401, cors);
+  const list = await env.VISITORS.list({ prefix: "w:" });
+  const messages = [];
+  for (const k of list.keys) {
+    const val = await env.VISITORS.get(k.name);
+    if (val) messages.push({ key: k.name, ...JSON.parse(val) });
+  }
+  return json({ messages }, 200, cors);
+}
+
+async function wallDelete(request, env, cors) {
+  if (!authed(request, env)) return json({ error: "unauthorized" }, 401, cors);
+  const body = await request.json().catch(() => ({}));
+  if (!body.key || !String(body.key).startsWith("w:")) return json({ error: "bad key" }, 400, cors);
+  await env.VISITORS.delete(String(body.key));
+  return json({ ok: true }, 200, cors);
+}
+
+function json(obj, status, headers) {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}

--- a/cloudflare/visitors-wrangler.toml
+++ b/cloudflare/visitors-wrangler.toml
@@ -1,0 +1,7 @@
+name = "tbd-visitors"
+main = "visitors-worker.js"
+compatibility_date = "2025-01-01"
+
+[[kv_namespaces]]
+binding = "VISITORS"
+id = "tbd-visitors"

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
     <script src="js/boot.js"></script>
     <script src="js/include-components.js"></script>
     <script src="js/site-data.js"></script>
+    <script src="js/presence.js"></script>
     <script src="js/main.js"></script>
     <script src="js/index-redirect.js"></script>
     <script src="js/term-core.js"></script>

--- a/js/now-data.js
+++ b/js/now-data.js
@@ -3,6 +3,7 @@
 // drops its line. No errors escape.
 (function () {
   var WORKER = "https://tbd-spotify.tomerno6.workers.dev";
+  var VISITORS = "https://tbd-visitors.tomerno6.workers.dev";
   var D = window.TbdData;
 
   function j(url) {
@@ -19,10 +20,19 @@
         withTimeout(j(WORKER + "/now"), 2500),
         D.posts(),
         D.songlog(),
-        D.discogs()
+        D.discogs(),
+        withTimeout(j(VISITORS + "/wall"), 2000),
+        withTimeout(j(VISITORS + "/presence"), 2000)
       ]).then(function (results) {
-        var now = results[0], posts = results[1], tracks = results[2], discogs = results[3];
+        var now = results[0], posts = results[1], tracks = results[2], discogs = results[3], wall = results[4], presence = results[5];
         var out = {};
+
+        if (wall && Array.isArray(wall.messages) && wall.messages.length) {
+          out.wall = { text: wall.messages[0].text, url: null };
+        }
+        if (presence && typeof presence.here === "number" && presence.here >= 2) {
+          out.presence = { text: presence.here + " on the site right now", url: null };
+        }
 
         if (now && now.track) {
           out.nowPlaying = {
@@ -100,6 +110,8 @@
       if (data.nowPlaying) L.push({ label: data.nowPlaying.live ? "▸ now playing" : "▸ last played", text: data.nowPlaying.text, url: data.nowPlaying.url });
       if (data.lastSeen) L.push({ label: "◈ last seen", text: data.lastSeen.text, url: data.lastSeen.url });
       if (data.onThisDay) L.push({ label: "◷ on this day", text: data.onThisDay.text, url: data.onThisDay.url });
+      if (data.presence) L.push({ label: "◉ here now", text: data.presence.text, url: data.presence.url });
+      if (data.wall) L.push({ label: "✉ the wall", text: data.wall.text, url: data.wall.url });
       if (data.latestTrack) L.push({ label: "♪ latest track", text: data.latestTrack.text, url: data.latestTrack.url });
       if (data.newestVinyl) L.push({ label: "◎ newest vinyl", text: data.newestVinyl.text, url: data.newestVinyl.url });
       if (data.latestPost) L.push({ label: "✎ latest post", text: data.latestPost.text, url: data.latestPost.url });

--- a/js/presence.js
+++ b/js/presence.js
@@ -1,0 +1,38 @@
+// Gentle presence: heartbeat to the visitors worker so the MOTD can say
+// "you + 2 others here". Session-scoped random id, 2-minute pulse, and
+// total silence when the worker is unreachable.
+(function () {
+  var WORKER = "https://tbd-visitors.tomerno6.workers.dev";
+  var latest = null;
+
+  function sessionId() {
+    try {
+      var id = sessionStorage.getItem("tbd-presence-id");
+      if (!id) {
+        id = Math.random().toString(36).slice(2, 12) + Date.now().toString(36);
+        sessionStorage.setItem("tbd-presence-id", id);
+      }
+      return id;
+    } catch (e) {
+      return "anon";
+    }
+  }
+
+  function beat() {
+    fetch(WORKER + "/presence", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: sessionId() }),
+    })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (d) { latest = d && typeof d.here === "number" ? d.here : null; })
+      .catch(function () { latest = null; });
+  }
+
+  beat();
+  setInterval(beat, 120000);
+
+  window.TbdPresence = {
+    here: function () { return latest; },
+  };
+})();

--- a/js/term-commands.js
+++ b/js/term-commands.js
@@ -7,6 +7,7 @@
 // Commands are { desc, run(args) } — same shape the terminals already use.
 (function () {
   var PAGES = ["blog", "travel", "music", "projects", "stats"];
+  var VISITORS_WORKER = "https://tbd-visitors.tomerno6.workers.dev";
   var D = window.TbdData;
 
   // Thin callback adapters over the shared data layer
@@ -534,6 +535,54 @@
           hidden: true,
           desc: "",
           run: function () { runShuffle(); },
+        },
+
+        wall: {
+          desc: "the visitors' wall — wall <a line> to write on it",
+          run: function (args) {
+            var text = args.join(" ").trim();
+            if (!text) {
+              fetch(VISITORS_WORKER + "/wall")
+                .then(function (r) { return r.ok ? r.json() : null; })
+                .then(function (d) {
+                  if (!d || !Array.isArray(d.messages)) {
+                    line("the wall is unreachable.", "term-err");
+                    return;
+                  }
+                  if (!d.messages.length) {
+                    line("the wall is blank. be the first: " + term.cmd("wall hello", "wall <something>"), "term-dim");
+                    return;
+                  }
+                  d.messages.forEach(function (m) {
+                    var el = line("", "");
+                    var date = document.createElement("span");
+                    date.className = "term-dim";
+                    date.textContent = new Date(m.ts).toISOString().slice(0, 10) + "  ";
+                    var bdi = document.createElement("bdi");
+                    bdi.textContent = m.text;
+                    el.appendChild(date);
+                    el.appendChild(bdi);
+                  });
+                })
+                .catch(function () { line("the wall is unreachable.", "term-err"); });
+              return;
+            }
+            if (text.length > 120) {
+              line("keep it under 120 characters — it's a wall, not a blog.", "term-err");
+              return;
+            }
+            fetch(VISITORS_WORKER + "/wall", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ text: text }),
+            })
+              .then(function (r) {
+                if (r.ok) { line("posted. the wall remembers.", "term-dim"); return; }
+                if (r.status === 429) { line("the wall needs a breather — three lines an hour.", "term-err"); return; }
+                line("the wall refused that one.", "term-err");
+              })
+              .catch(function () { line("the wall is unreachable.", "term-err"); });
+          },
         },
 
         crt: {

--- a/js/term-overlay.js
+++ b/js/term-overlay.js
@@ -60,6 +60,7 @@
             ["grep osaka", "search the posts"],
             ["post", "the corpus (post day 107, post today, post shuffle)"],
             ["now", "what's happening"],
+            ["wall", "the visitors' wall (wall <a line> to write)"],
             ["crt", "toggle the screen effect"],
             ["exit", "close (or esc)"],
           ].forEach(function (c) {
@@ -73,6 +74,7 @@
       post: common.post,
       day: common.day,
       shuffle: common.shuffle,
+      wall: common.wall,
       now: common.now,
       crt: common.crt,
       clear: { desc: "", run: function () { term.clear(); } },

--- a/js/terminal.js
+++ b/js/terminal.js
@@ -59,6 +59,7 @@
     post: common.post,
     day: common.day,
     shuffle: common.shuffle,
+    wall: common.wall,
     whoami: {
       desc: "who is tbd anyway",
       run: function () {
@@ -208,17 +209,43 @@
     return n;
   }
 
+  // The site remembers every attempt — globally. Resolves to null when
+  // the visitors worker is silent, and the line degrades to local-only.
+  function reportMeltdown(localCount) {
+    return fetch("https://tbd-visitors.tomerno6.workers.dev/meltdown", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ first: localCount === 1 }),
+    })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (d) { return d && typeof d.attempts === "number" ? d : null; })
+      .catch(function () { return null; });
+  }
+
+  function aftermathLine(localCount, global) {
+    var text = "(that was attempt #" + localCount + " for you";
+    if (global) {
+      text += ", #" + global.attempts.toLocaleString("en-US") + " globally";
+      if (global.vandals > 1) text += " — you are one of " + global.vandals.toLocaleString("en-US") + " vandals";
+    }
+    return text + ". the site remembers.)";
+  }
+
   function meltdown() {
     melting = true;
     var hadCrt = document.cookie.split("; ").some(function (r) { return r === "crt=1"; });
+    var localCount = meltdownCount();
+    var globalPromise = reportMeltdown(localCount);
 
     if (reducedMotion) {
       // The quiet apocalypse
       line("rm: descending into /…", "term-err");
       line("removing everything. done.", "term-err");
       line("everything is fine. nothing was lost.", "term-dim");
-      line("(that was attempt #" + meltdownCount() + ".)", "term-dim");
-      melting = false;
+      globalPromise.then(function (global) {
+        line(aftermathLine(localCount, global), "term-dim");
+        melting = false;
+      });
       return;
     }
 
@@ -281,9 +308,11 @@
           if (!hadCrt) document.body.classList.remove("crt");
           setTimeout(function () {
             line("everything is fine. nothing was lost.", "term-dim");
-            line("(that was attempt #" + meltdownCount() + ". the site remembers.)", "term-dim");
-            melting = false;
-            term.focus();
+            globalPromise.then(function (global) {
+              line(aftermathLine(localCount, global), "term-dim");
+              melting = false;
+              term.focus();
+            });
           }, 500);
         }
         function onKey(e) {

--- a/music.html
+++ b/music.html
@@ -41,6 +41,7 @@
     <footer></footer>
     <script src="js/include-components.js"></script>
     <script src="js/site-data.js"></script>
+    <script src="js/presence.js"></script>
     <script src="js/term-core.js"></script>
     <script src="js/term-commands.js"></script>
     <script src="js/now-data.js"></script>

--- a/projects.html
+++ b/projects.html
@@ -33,6 +33,7 @@
     <footer></footer>
     <script src="js/include-components.js"></script>
     <script src="js/site-data.js"></script>
+    <script src="js/presence.js"></script>
     <script src="js/main.js"></script>
     <script src="js/term-core.js"></script>
     <script src="js/term-commands.js"></script>

--- a/stats.html
+++ b/stats.html
@@ -86,6 +86,7 @@
     <script src="js/main.js"></script>
     <script src="js/include-components.js"></script>
     <script src="js/site-data.js"></script>
+    <script src="js/presence.js"></script>
     <script src="js/term-core.js"></script>
     <script src="js/term-commands.js"></script>
     <script src="js/now-data.js"></script>

--- a/tests/smoke/visitors.spec.js
+++ b/tests/smoke/visitors.spec.js
@@ -1,0 +1,82 @@
+const { test, expect } = require("@playwright/test");
+const { phosphorPage, typeCmd } = require("../helpers");
+
+const V = "https://tbd-visitors.tomerno6.workers.dev";
+const CORS = { "Access-Control-Allow-Origin": "*" };
+
+function mockVisitors(page, { here = 3, messages, meltdown } = {}) {
+  return Promise.all([
+    page.route(V + "/wall", (r) => {
+      if (r.request().method() === "POST") {
+        const text = JSON.parse(r.request().postData() || "{}").text || "";
+        if (text.includes("ratelimitme")) return r.fulfill({ status: 429, json: { error: "rate limited" }, headers: CORS });
+        return r.fulfill({ json: { ok: true }, headers: CORS });
+      }
+      return r.fulfill({
+        json: { messages: messages || [{ text: "hello from berlin", ts: 1751900000000 }] },
+        headers: CORS,
+      });
+    }),
+    page.route(V + "/presence", (r) => r.fulfill({ json: { here }, headers: CORS })),
+    page.route(V + "/meltdown", (r) =>
+      r.fulfill({ json: meltdown || { attempts: 1247, vandals: 88 }, headers: CORS })
+    ),
+  ]);
+}
+
+test("the wall: read, write, rate-limit", async ({ page }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());
+  await mockVisitors(page);
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#term-input");
+  await typeCmd(page, "wall");
+  await expect(page.locator(".term-scrollback")).toContainText("hello from berlin");
+  await typeCmd(page, "wall greetings from the suite");
+  await expect(page.locator(".term-scrollback")).toContainText("posted. the wall remembers.");
+  await typeCmd(page, "wall ratelimitme");
+  await expect(page.locator(".term-scrollback")).toContainText("needs a breather");
+  expect(errors).toEqual([]);
+});
+
+test("MOTD gains presence and the latest wall line", async ({ page }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());
+  await mockVisitors(page, { here: 3 });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#motd.visible", { timeout: 15000 });
+  await expect(page.locator("#motd")).toContainText("3 on the site right now");
+  await expect(page.locator("#motd")).toContainText("the wall");
+  await expect(page.locator("#motd")).toContainText("hello from berlin");
+  expect(errors).toEqual([]);
+});
+
+test("meltdown reports the global tally", async ({ page }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());
+  await mockVisitors(page);
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#term-input");
+  await typeCmd(page, "rm -rf --no-preserve-root /", "#term-input", 600);
+  await expect(page.locator(".term-scrollback")).toContainText("attempt #1 for you, #1,247 globally");
+  await expect(page.locator(".term-scrollback")).toContainText("one of 88 vandals");
+  expect(errors).toEqual([]);
+});
+
+test("everything degrades when the visitors worker is silent", async ({ page }) => {
+  const errors = await phosphorPage(page);
+  await page.route("https://tbd-spotify.tomerno6.workers.dev/**", (r) => r.abort());
+  await page.route(V + "/**", (r) => r.abort());
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("#term-input");
+  await typeCmd(page, "wall");
+  await expect(page.locator(".term-scrollback")).toContainText("the wall is unreachable");
+  await typeCmd(page, "rm -rf --no-preserve-root /", "#term-input", 600);
+  await expect(page.locator(".term-scrollback")).toContainText("attempt #1 for you. the site remembers.");
+  await page.waitForSelector("#motd.visible", { timeout: 15000 });
+  await expect(page.locator("#motd")).not.toContainText("the wall");
+  await expect(page.locator("#motd")).not.toContainText("right now");
+  expect(errors).toEqual([]);
+});

--- a/travel.html
+++ b/travel.html
@@ -37,6 +37,7 @@
     <script src="https://cdn.jsdelivr.net/npm/leaflet-ant-path@1.3.0/dist/leaflet-ant-path.js" integrity="sha384-OEj5w5dYIX4MUvZAeaQ/7L8HGNi6Qtb54Yl6dY1sUQyUiOuxeUznR8DOvAWHGpOx" crossorigin="anonymous"></script>
     <script src="js/include-components.js"></script>
     <script src="js/site-data.js"></script>
+    <script src="js/presence.js"></script>
     <script src="js/term-core.js"></script>
     <script src="js/term-commands.js"></script>
     <script src="js/now-data.js"></script>


### PR DESCRIPTION
The static site gains memory between visitors — one worker (`tbd-visitors`), one KV namespace, three capabilities:

- **The wall**: `wall hello from berlin` in any terminal writes a line (≤120 chars, 3/hour/IP, pruned to the newest 50); bare `wall` reads the latest 10; the MOTD whispers the newest (`✉ the wall: …`). Moderation via Bearer STATS_SECRET (`/wall/all`, `/wall/delete`).
- **Presence**: a 2-minute session heartbeat (TTL'd KV keys) → the MOTD shows `◉ here now: 3 on the site right now` — only when there's actual company.
- **Global meltdown tally**: `rm -rf /` reports `(that was attempt #4 for you, #1,247 globally — you are one of 88 vandals. the site remembers.)` — distinct-vandal counting via the client's first-time flag.

Everything degrades to complete silence until deployed. **Deploy** (bundles with the pending worker redeploys):
```
wrangler kv namespace create tbd-visitors   # put the id in visitors-wrangler.toml
wrangler secret put STATS_SECRET -c cloudflare/visitors-wrangler.toml
wrangler deploy -c cloudflare/visitors-wrangler.toml
```

Suite: 30 passed (4 new specs: wall read/write/rate-limit, MOTD lines, global tally, full degradation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfBxiag3CF98qZxsGWKAMh